### PR TITLE
Adds proper JSON response to Revoke method

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -93,5 +93,6 @@ def revoke(token):
     """POST handler to revoke a shortened link by token"""
     try:
         store.revoke(token)
+        return jsonify({'success': 'hey nice job'}, 200)
     except RevokeError as e:
         return jsonify({'error': e}, 400)


### PR DESCRIPTION
Closes #6: Revoke response now returns

```
{
  "status": "okay",
  "success": "hey nice job"
}
```