### PR TITLE
Adds API key

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,9 +14,11 @@ In practice, I disabled Docker (`dockerizePip: false` in `serverless.yml`) becau
 
 ## Env vars
 
-There is only one variable to set in v1:
-
-- `COMPOSE_REDIS_URL`: Full Redis connection URL, of the form `redis://user:password@redisurl.com:123`
+| Env var               | Description                                                                                         |
+|-----------------------|-----------------------------------------------------------------------------------------------------|
+| `COMPOSE_REDIS_URL`   | Full Redis connection URL, of the form `redis://user:password@redisurl.com:123`                     |
+| `BERTLY_API_KEY_NAME` | Name of the header used to pass the API key. The key is required for the create and revoke methods. |
+| `BERTLY_API_KEY`      | The API key value.                                                                                  |
 
 In theory, we should be able to use the [AWS SSM Parameter Store](https://hackernoon.com/you-should-use-ssm-parameter-store-over-lambda-env-variables-5197fc6ea45b) service, which provides access across applications within AWS. In practice, the Heroku-style, [per-app environment variable setting](https://docs.aws.amazon.com/lambda/latest/dg/env_variables.html) is adequate here. We're not planning to reuse this app's Redis store elsewhere.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ environment:
   COMPOSE_REDIS_URL: '${ssm:bertly-redis-url}'
 ```
 
-For Lambda env vars, just set the `COMPOSE_REDIS_URL` value on the deployed Lambda Function's configuration screen: https://cl.ly/081F0V0G3z2p
+For Lambda env vars, just set the values on the deployed Lambda Function's configuration screen: https://cl.ly/081F0V0G3z2p
 
 ## Deploying
 

--- a/bertly.py
+++ b/bertly.py
@@ -14,17 +14,18 @@
     :license: MIT, see LICENSE for details
 """
 
-import redis
 import os
+import redis
+
 from flask import Flask, request, redirect, url_for, abort
 from flask import jsonify as _jsonify
 from functools import wraps
+from rfc3987 import parse
 from shorten import RedisStore, NamespacedFormatter, UUIDTokenGenerator
 from shorten import alphabets
 from shorten import RevokeError
-from rfc3987 import parse
-from werkzeug import iri_to_uri
 from urlparse import urlparse
+from werkzeug import iri_to_uri
 
 app = Flask(__name__)
 

--- a/bertly.py
+++ b/bertly.py
@@ -16,8 +16,9 @@
 
 import redis
 import os
-from flask import Flask, request, redirect, url_for
+from flask import Flask, request, redirect, url_for, abort
 from flask import jsonify as _jsonify
+from functools import wraps
 from shorten import RedisStore, NamespacedFormatter, UUIDTokenGenerator
 from shorten import alphabets
 from shorten import RevokeError
@@ -32,6 +33,7 @@ compose_redis_url = os.environ.get('COMPOSE_REDIS_URL')
 if not compose_redis_url:
     app.logger.error("No Redis URL")
 
+## Establish Redis connection as redis_client
 ssl_wanted=compose_redis_url.startswith("rediss:")
 parsed = urlparse(compose_redis_url)
 ssl_wanted=compose_redis_url.startswith("rediss:")
@@ -54,6 +56,25 @@ def jsonify(obj, status_code=200):
 def valid_url(url):
     return bool(parse(url, rule='URI_reference'))
 
+def require_api_key(view_function):
+    """Decorator to require API key in header, passed as api_key_label"""
+    @wraps(view_function)
+    def decorated_function(*args, **kwargs):
+
+        api_key_label = os.environ.get('BERTLY_API_KEY_NAME')
+        api_key = os.environ.get('BERTLY_API_KEY')
+
+        if not api_key_label:
+            app.logger.error("No name for API key: Should be defined in environment as BERTLY_API_KEY_NAME")
+            abort(401)
+        if request.headers.get(api_key_label) and request.headers.get(api_key_label) == api_key:
+            return view_function(*args, **kwargs)
+        else:
+            received_api_key = request.headers.get(api_key_label) or "[None]"
+            app.logger.warning("Incorrect API key header: " + api_key_label + ' = ' + received_api_key)
+            abort(401)
+    return decorated_function
+
 ###########################################################
 
 # The Redis store persists original URL, shortened key, and revocation token.
@@ -65,6 +86,7 @@ store = RedisStore(redis_client=redis_client,
     alphabet=alphabets.URLSAFE_DISSIMILAR)
 
 @app.route('/', methods=['POST'])
+@require_api_key
 def shorten():
     """POST handler to shorten a URL"""
     url = request.form['url'].strip()
@@ -89,6 +111,7 @@ def bounce(key):
         return jsonify({'error': 'url not found'}, 400)
 
 @app.route('/revoke/<token>', methods=['POST'])
+@require_api_key
 def revoke(token):
     """POST handler to revoke a shortened link by token"""
     try:


### PR DESCRIPTION
#### What's this PR do?
This update adds a decorator to check for an API key passed as a header:

`X-BERTLY-API-KEY: mytestkey`

Both key name and value get defined as env vars: `BERTLY_API_KEY_NAME` and `BERTLY_API_KEY`. See `INSTALL.md` for details.

The decorator wraps the `create` and `revoke` Flask routes.

#### How should this be reviewed?

Given that you invoke the app with `BERTLY_API_KEY_NAME` and `BERTLY_API_KEY` defined in the environment, requests to `POST /` and `POST /revoke/<token>` should fail without the correct header.

#### Any background context you want to provide?
N/A

#### Relevant tickets
Fixes #5 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
