### PR TITLE
Add `GET <key>/clicks` route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ HINT: Make sure to URL-encode arguments: `?x=test&y=this_thing&z=the-other-thing
 
 Example response:
 
-```
+```json
 {
   "revoke": "https://bertlydeployed.com/revoke/491dcfe3-7715-479c-a32b-bad375992e20",
   "status": "okay",
@@ -34,6 +34,24 @@ Example response:
 
 `GET /<key>`
 
+## Get clicks
+
+`GET /<key>/clicks`
+
+Example request:
+
+`curl https://bertlydeployed.com/32s`
+
+Response:
+
+```json
+{
+  "status": "okay",
+  "url": "http://thepretenders.com",
+  "count": 3
+}
+```
+
 ## Revoke redirect
 
 `POST /revoke/<token>`
@@ -44,7 +62,7 @@ Example request:
 
 Response:
 
-```
+```json
 {
   "status": "okay",
   "success": "hey nice job"

--- a/bertly.py
+++ b/bertly.py
@@ -153,6 +153,23 @@ def bounce(key):
     # Process redirect even if we fail to record the click.
     return redirect(iri_to_uri(url))
 
+
+# ROUTE: GET /<key>/clicks
+@app.route('/<key>/clicks', methods=['GET'])
+def clicks(key):
+    """GET handler to count clicks on a shortened key"""
+    try:
+        url = store[key]
+
+    except KeyError:
+        abort(404)
+
+    # Find the number of clicks for this shortened URL:
+    count = db.session.query(Click).filter(Click.shortened == key).count()
+
+    return jsonify({'url': url, 'count': count}, 200)
+
+
 # ROUTE: POST /revoke/<token>
 @app.route('/revoke/<token>', methods=['POST'])
 @require_api_key

--- a/migrations/versions/42a810a76302_add_shortened_index.py
+++ b/migrations/versions/42a810a76302_add_shortened_index.py
@@ -6,7 +6,6 @@ Create Date: 2018-05-31 14:40:05.795057
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/42a810a76302_add_shortened_index.py
+++ b/migrations/versions/42a810a76302_add_shortened_index.py
@@ -1,0 +1,24 @@
+"""Add shortened index.
+
+Revision ID: 42a810a76302
+Revises: 37ba37319784
+Create Date: 2018-05-31 14:40:05.795057
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '42a810a76302'
+down_revision = '37ba37319784'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('shortened_index', 'clicks', ['shortened'])
+
+
+def downgrade():
+    op.drop_index('shortened_index', 'clicks')


### PR DESCRIPTION
This pull request adds a `GET <key>/clicks` route to see how many clicks a given short-link has. This will be used by Phoenix's new "Social Drive Action" to show users how many people have used their voter registration link!

Closes #20.

![screen shot 2018-05-31 at 10 58 32 am](https://user-images.githubusercontent.com/583202/40789915-967a44ae-64c1-11e8-9f39-1a79d7978f34.png)
