### PR TITLE
Normalize URLs before shortening.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -31,6 +31,7 @@ from functools import wraps
 from models import db, Click
 from rfc3987 import parse
 from urlparse import urlparse
+from url_normalize import url_normalize
 from werkzeug import iri_to_uri
 
 # Create Flask app & initialize extensions.
@@ -70,6 +71,7 @@ Helper functions & decorators
 
 def get_key_for_url(url):
     """Given a URL, (create and) return a shortened key."""
+    url = url_normalize(url)
     hash = hashlib.sha256(url.encode()).hexdigest()
     key = redis_client.get('bertly:url:{}'.format(hash))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,5 @@ s3transfer==0.1.13
 short-url==1.2.2
 six==1.11.0
 SQLAlchemy==1.2.7
+url-normalize==1.3.3
 Werkzeug==0.12.2


### PR DESCRIPTION
This just fixes up some edge cases where we could either accidentally shorten a relative URL (e.g. `www.starwars.com` → `https://dosome.click/gneqk` → `http://dosome.click/www.starwars.com`) or make multiple short-links to the same "canonical" URL (e.g. `http://www.StarWars.com/?`, which should have the same shortlink as `http://www.starwars.com`).