### PR TITLE
Remove `iri_to_uri` filter on redirect.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -32,7 +32,6 @@ from models import db, Click
 from rfc3987 import parse
 from urlparse import urlparse
 from url_normalize import url_normalize
-from werkzeug import iri_to_uri
 
 # Create Flask app & initialize extensions.
 app = Flask(__name__)
@@ -164,7 +163,7 @@ def bounce(key):
     db.session.commit()
 
     # Process redirect even if we fail to record the click.
-    return redirect(iri_to_uri(url))
+    return redirect(url)
 
 
 # ROUTE: GET /<key>/clicks


### PR DESCRIPTION
This pull request removes the [`iri_to_uri`](http://werkzeug.pocoo.org/docs/0.14/urls/#werkzeug.urls.iri_to_uri) filter being applied to URLs before we redirect them. This causes URLs with special characters to be improperly decoded, e.g. `https://medium.com/@susanbordo` to `https://medium.com/%40susanbordo`.

From what I can tell, this should be safe to do since we're normalizing URLs that we store now with [`url-normalize`](https://github.com/niksite/url-normalize) before storing them in Redis, and that would handle transforming URLs with unicode characters to IRIs without munging other valid characters:

```py
from url_normalize import url_normalize

print(url_normalize('http://www.medium.com/@susanbordo'))
# → http://www.medium.com/@susanbordo

print(url_normalize(u'http://☃.net/'))
# → u'http://xn--n3h.net/'

```

Closes #24.