### PR TITLE
Use UUIDs for `click_id` column.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -32,6 +32,7 @@ from models import db, Click
 from rfc3987 import parse
 from urlparse import urlparse
 from url_normalize import url_normalize
+from uuid import uuid4
 
 # Create Flask app & initialize extensions.
 app = Flask(__name__)
@@ -156,8 +157,7 @@ def bounce(key):
         abort(404)
 
     # Record new click. See models.py for data definition
-    id = key + str(time.time())
-    click = Click(click_id=id, click_time=datetime.utcnow(),
+    click = Click(click_id=uuid4(), click_time=datetime.utcnow(),
                   shortened=key, target_url=url)
     db.session.add(click)
     db.session.commit()


### PR DESCRIPTION
This pull request swaps the `clicks_id` column to be filled with `uuid.uuid4()`, instead of using the current timestamp. This should significantly reduce the risk of a collision when we have a lot of clicks being logged all at once. From [Wikipedia](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)):

> …for there to be a one in a billion chance of duplication, 103 trillion version 4 UUIDs must be generated.

So, pretty unlikely. 👌 Closes #28.