### PR TITLE
Provision resources with CloudFormation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# macOS
+.DS_Store
+
 # C extensions
 *.so
 

--- a/config.py
+++ b/config.py
@@ -18,4 +18,13 @@ POSTGRES_URL = (
     '%(pw)s@%(host)s:%(port)s/%(db)s') % POSTGRES
 
 # Redis
-REDIS_URL = os.getenv('COMPOSE_REDIS_URL')
+if (os.getenv('COMPOSE_REDIS_URL')):
+    REDIS_URL = os.getenv('COMPOSE_REDIS_URL')
+else:
+    REDIS = {
+        'host':  os.getenv('REDIS_HOST'),
+        'port': os.getenv('REDIS_PORT')
+    }
+
+    REDIS_URL = ('redis://%(host)s:%(port)s') % REDIS
+

--- a/config.py
+++ b/config.py
@@ -27,4 +27,3 @@ else:
     }
 
     REDIS_URL = ('redis://%(host)s:%(port)s') % REDIS
-

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,8 @@
+from flask_migrate import upgrade
+from bertly import app
+
+
+def run(event, context):
+    """Run outstanding migrations."""
+    with app.app_context():
+        upgrade()

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,13 +1,15 @@
 # A generic, single database configuration.
 
 [alembic]
+# path to migration scripts
+script_location=migrations
+
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
 
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
-
 
 # Logging configuration
 [loggers]

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "main": "index.js",
   "scripts": {
     "start": "serverless wsgi serve",
-    "deploy:dev": "serverless --aws-profile serverless-dev deploy",
-    "deploy:prod": "serverless --aws-profile serverless-production deploy",
+    "deploy:dev": "serverless deploy --aws-profile serverless-dev --stage dev",
+    "deploy:prod": "serverless deploy --aws-profile serverless-production --stage prod",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "serverless wsgi serve",
     "deploy:dev": "serverless deploy --aws-profile serverless-dev --stage dev",
+    "deploy:qa": "serverless deploy --aws-profile serverless-dev --stage qa",
     "deploy:prod": "serverless deploy --aws-profile serverless-production --stage prod",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "serverless-wsgi": "^1.3.0"
   },
   "dependencies": {
-    "serverless": "^1.27.2",
-    "serverless-dynamodb-local": "^0.2.30"
+    "serverless": "^1.27.2"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -38,6 +38,7 @@ provider:
     POSTGRES_PORT: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Port" ] }
     REDIS_HOST: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Address" ] }
     REDIS_PORT: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Port" ] }
+    BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}
 
 functions:
   app:

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,6 +36,9 @@ provider:
   environment:
     POSTGRESQL_HOST: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Address" ] }
     POSTGRESQL_PORT: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Port" ] }
+    POSTGRESQL_USER: ${ssm:/bertly/dev/postgres-user}
+    POSTGRESQL_PASSWORD: ${ssm:/bertly/dev/postgres-password~true}
+    POSTGRESQL_DB: 'bertly_clicks'
     REDIS_HOST: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Address" ] }
     REDIS_PORT: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Port" ] }
     BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,11 @@ provider:
   runtime: python2.7
   stage: dev
   region: us-east-1
+  environment:
+    POSTGRES_HOST: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Address" ] }
+    POSTGRES_PORT: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Port" ] }
+    REDIS_HOST: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Address" ] }
+    REDIS_PORT: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Port" ] }
 
 functions:
   app:
@@ -40,3 +45,79 @@ functions:
     events:
       - http: ANY /
       - http: 'ANY {proxy+}'
+
+resources:
+  Resources:
+    ServerlessVPC:
+      Type: AWS::EC2::VPC
+      Properties:
+        CidrBlock: "10.0.0.0/16"
+    ServerlessSubnet:
+      DependsOn: ServerlessVPC
+      Type: AWS::EC2::Subnet
+      Properties:
+        VpcId:
+          Ref: ServerlessVPC
+        AvailabilityZone: ${self:provider.region}a
+        CidrBlock: "10.0.0.0/24"
+    ServerlessSecurityGroup:
+      DependsOn: ServerlessVPC
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+        GroupDescription: SecurityGroup for Serverless Functions
+        VpcId:
+          Ref: ServerlessVPC
+    ServerlessStorageSecurityGroup:
+      DependsOn: ServerlessVPC
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+        GroupDescription: Ingress for Serverless Redis & RDS
+        VpcId:
+          Ref: ServerlessVPC
+        SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '5432'
+          ToPort: '5432'
+          SourceSecurityGroupId:
+            Ref: ServerlessSecurityGroup
+        - IpProtocol: tcp
+          FromPort: '11211'
+          ToPort: '11211'
+          SourceSecurityGroupId:
+            Ref: ServerlessSecurityGroup
+    ServerlessRDSSubnetGroup:
+      Type: AWS::RDS::DBSubnetGroup
+      Properties:
+        DBSubnetGroupDescription: "RDS Subnet Group"
+        SubnetIds:
+        - Ref: ServerlessSubnet
+    ServerlessRDSCluster:
+      DependsOn: ServerlessStorageSecurityGroup
+      Type: AWS::RDS::DBInstance
+      Properties:
+        Engine: Postgres 
+        EngineVersion: '10.3'
+        DBName: 'bertly_clicks'
+        AllocatedStorage: 10
+        DBInstanceClass: db.t2.small
+        VPCSecurityGroups:
+        - "Fn::GetAtt": ServerlessStorageSecurityGroup.GroupId
+        DBSubnetGroupName:
+          Ref: ServerlessRDSSubnetGroup
+    ServerlessElasticacheSubnetGroup:
+      Type: AWS::ElastiCache::SubnetGroup
+      Properties:
+        Description: "Cache Subnet Group"
+        SubnetIds:
+        - Ref: ServerlessSubnet
+    ServerlessElasticacheCluster:
+      DependsOn: ServerlessStorageSecurityGroup
+      Type: AWS::ElastiCache::CacheCluster
+      Properties:
+        Engine: redis
+        NumCacheNodes: 1
+        CacheNodeType: cache.r4.large
+        VpcSecurityGroupIds:
+        - "Fn::GetAtt": ServerlessStorageSecurityGroup.GroupId
+        CacheSubnetGroupName:
+          Ref: ServerlessElasticacheSubnetGroup

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,9 +2,8 @@ service: bertly
 
 plugins:
   - serverless-python-requirements
-  - serverless-wsgi
-  - serverless-dynamodb-local
   - serverless-domain-manager
+  - serverless-wsgi
 
 custom:
   domainEnabled:
@@ -34,17 +33,21 @@ provider:
   stage: dev
   region: us-east-1
   environment:
-    POSTGRESQL_HOST: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Address" ] }
-    POSTGRESQL_PORT: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Port" ] }
+    BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}
     POSTGRESQL_USER: ${ssm:/bertly/dev/postgres-user}
     POSTGRESQL_PASSWORD: ${ssm:/bertly/dev/postgres-password~true}
     POSTGRESQL_DB: 'bertly_clicks'
-    REDIS_HOST: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Address" ] }
-    REDIS_PORT: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Port" ] }
-    BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}
+    POSTGRESQL_HOST:
+      'Fn::GetAtt': [ServerlessRDSCluster, 'Endpoint.Address']
+    POSTGRESQL_PORT:
+      'Fn::GetAtt': [ServerlessRDSCluster, 'Endpoint.Port']
+    REDIS_HOST:
+      'Fn::GetAtt': [ServerlessElasticacheCluster, 'RedisEndpoint.Address']
+    REDIS_PORT:
+      'Fn::GetAtt': [ServerlessElasticacheCluster, 'RedisEndpoint.Port']
   vpc:
     securityGroupIds:
-      - "Fn::GetAtt": ServerlessSecurityGroup.GroupId
+      - 'Fn::GetAtt': ServerlessSecurityGroup.GroupId
     subnetIds:
       - Ref: ServerlessSubnetA
       - Ref: ServerlessSubnetB
@@ -64,7 +67,7 @@ resources:
     ServerlessVPC:
       Type: AWS::EC2::VPC
       Properties:
-        CidrBlock: "10.0.0.0/16"
+        CidrBlock: '10.0.0.0/16'
     ServerlessSubnetA:
       DependsOn: ServerlessVPC
       Type: AWS::EC2::Subnet
@@ -72,7 +75,7 @@ resources:
         VpcId:
           Ref: ServerlessVPC
         AvailabilityZone: ${self:provider.region}a
-        CidrBlock: "10.0.0.0/24"
+        CidrBlock: '10.0.0.0/24'
     ServerlessSubnetB:
       DependsOn: ServerlessVPC
       Type: AWS::EC2::Subnet
@@ -80,7 +83,7 @@ resources:
         VpcId:
           Ref: ServerlessVPC
         AvailabilityZone: ${self:provider.region}c
-        CidrBlock: "10.0.1.0/24"
+        CidrBlock: '10.0.1.0/24'
     ServerlessSubnetC:
       DependsOn: ServerlessVPC
       Type: AWS::EC2::Subnet
@@ -88,7 +91,7 @@ resources:
         VpcId:
           Ref: ServerlessVPC
         AvailabilityZone: ${self:provider.region}d
-        CidrBlock: "10.0.2.0/24"
+        CidrBlock: '10.0.2.0/24'
     ServerlessSecurityGroup:
       DependsOn: ServerlessVPC
       Type: AWS::EC2::SecurityGroup
@@ -117,7 +120,7 @@ resources:
     ServerlessRDSSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup
       Properties:
-        DBSubnetGroupDescription: "RDS Subnet Group"
+        DBSubnetGroupDescription: 'RDS Subnet Group'
         SubnetIds:
         - Ref: ServerlessSubnetA
         - Ref: ServerlessSubnetB
@@ -134,13 +137,13 @@ resources:
         MasterUsername: ${ssm:/bertly/dev/postgres-user}
         MasterUserPassword: ${ssm:/bertly/dev/postgres-password~true}
         VPCSecurityGroups:
-        - "Fn::GetAtt": ServerlessStorageSecurityGroup.GroupId
+        - 'Fn::GetAtt': ServerlessStorageSecurityGroup.GroupId
         DBSubnetGroupName:
           Ref: ServerlessRDSSubnetGroup
     ServerlessElasticacheSubnetGroup:
       Type: AWS::ElastiCache::SubnetGroup
       Properties:
-        Description: "Cache Subnet Group"
+        Description: 'Cache Subnet Group'
         SubnetIds:
         - Ref: ServerlessSubnetA
         - Ref: ServerlessSubnetB
@@ -153,6 +156,6 @@ resources:
         NumCacheNodes: 1
         CacheNodeType: cache.r4.large
         VpcSecurityGroupIds:
-        - "Fn::GetAtt": ServerlessStorageSecurityGroup.GroupId
+        - 'Fn::GetAtt': ServerlessStorageSecurityGroup.GroupId
         CacheSubnetGroupName:
           Ref: ServerlessElasticacheSubnetGroup

--- a/serverless.yml
+++ b/serverless.yml
@@ -37,20 +37,20 @@ provider:
     POSTGRESQL_PASSWORD: ${ssm:/bertly/${opt:stage}/postgres-password~true}
     POSTGRESQL_DB: 'bertly_clicks'
     POSTGRESQL_HOST:
-      'Fn::GetAtt': [ServerlessRDSCluster, 'Endpoint.Address']
+      'Fn::GetAtt': [BertlyRDSCluster, 'Endpoint.Address']
     POSTGRESQL_PORT:
-      'Fn::GetAtt': [ServerlessRDSCluster, 'Endpoint.Port']
+      'Fn::GetAtt': [BertlyRDSCluster, 'Endpoint.Port']
     REDIS_HOST:
-      'Fn::GetAtt': [ServerlessElasticacheCluster, 'RedisEndpoint.Address']
+      'Fn::GetAtt': [BertlyElasticacheCluster, 'RedisEndpoint.Address']
     REDIS_PORT:
-      'Fn::GetAtt': [ServerlessElasticacheCluster, 'RedisEndpoint.Port']
+      'Fn::GetAtt': [BertlyElasticacheCluster, 'RedisEndpoint.Port']
   vpc:
     securityGroupIds:
-      - 'Fn::GetAtt': ServerlessSecurityGroup.GroupId
+      - 'Fn::GetAtt': BertlySecurityGroup.GroupId
     subnetIds:
-      - Ref: ServerlessSubnetA
-      - Ref: ServerlessSubnetB
-      - Ref: ServerlessSubnetC
+      - Ref: BertlySubnetA
+      - Ref: BertlySubnetB
+      - Ref: BertlySubnetC
 
 functions:
   app:
@@ -63,69 +63,69 @@ functions:
 
 resources:
   Resources:
-    ServerlessVPC:
+    BertlyVPC:
       Type: AWS::EC2::VPC
       Properties:
         CidrBlock: '10.0.0.0/16'
-    ServerlessSubnetA:
-      DependsOn: ServerlessVPC
+    BertlySubnetA:
+      DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
         VpcId:
-          Ref: ServerlessVPC
+          Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}a
         CidrBlock: '10.0.0.0/24'
-    ServerlessSubnetB:
-      DependsOn: ServerlessVPC
+    BertlySubnetB:
+      DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
         VpcId:
-          Ref: ServerlessVPC
+          Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}c
         CidrBlock: '10.0.1.0/24'
-    ServerlessSubnetC:
-      DependsOn: ServerlessVPC
+    BertlySubnetC:
+      DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
         VpcId:
-          Ref: ServerlessVPC
+          Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}d
         CidrBlock: '10.0.2.0/24'
-    ServerlessSecurityGroup:
-      DependsOn: ServerlessVPC
+    BertlySecurityGroup:
+      DependsOn: BertlyVPC
       Type: AWS::EC2::SecurityGroup
       Properties:
-        GroupDescription: SecurityGroup for Serverless Functions
+        GroupDescription: SecurityGroup for Bertly Functions
         VpcId:
-          Ref: ServerlessVPC
-    ServerlessStorageSecurityGroup:
-      DependsOn: ServerlessVPC
+          Ref: BertlyVPC
+    BertlyStorageSecurityGroup:
+      DependsOn: BertlyVPC
       Type: AWS::EC2::SecurityGroup
       Properties:
-        GroupDescription: Ingress for Serverless Redis & RDS
+        GroupDescription: Ingress for Bertly Redis & RDS
         VpcId:
-          Ref: ServerlessVPC
+          Ref: BertlyVPC
         SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: '5432'
           ToPort: '5432'
           SourceSecurityGroupId:
-            Ref: ServerlessSecurityGroup
+            Ref: BertlySecurityGroup
         - IpProtocol: tcp
           FromPort: '6379'
           ToPort: '6379'
           SourceSecurityGroupId:
-            Ref: ServerlessSecurityGroup
-    ServerlessRDSSubnetGroup:
+            Ref: BertlySecurityGroup
+    BertlyRDSSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup
       Properties:
         DBSubnetGroupDescription: 'RDS Subnet Group'
         SubnetIds:
-        - Ref: ServerlessSubnetA
-        - Ref: ServerlessSubnetB
-        - Ref: ServerlessSubnetC
-    ServerlessRDSCluster:
-      DependsOn: ServerlessStorageSecurityGroup
+        - Ref: BertlySubnetA
+        - Ref: BertlySubnetB
+        - Ref: BertlySubnetC
+    BertlyRDSCluster:
+      DependsOn: BertlyStorageSecurityGroup
       Type: AWS::RDS::DBInstance
       Properties:
         Engine: Postgres 
@@ -136,25 +136,25 @@ resources:
         MasterUsername: ${ssm:/bertly/${opt:stage}/postgres-user}
         MasterUserPassword: ${ssm:/bertly/${opt:stage}/postgres-password~true}
         VPCSecurityGroups:
-        - 'Fn::GetAtt': ServerlessStorageSecurityGroup.GroupId
+        - 'Fn::GetAtt': BertlyStorageSecurityGroup.GroupId
         DBSubnetGroupName:
-          Ref: ServerlessRDSSubnetGroup
-    ServerlessElasticacheSubnetGroup:
+          Ref: BertlyRDSSubnetGroup
+    BertlyElasticacheSubnetGroup:
       Type: AWS::ElastiCache::SubnetGroup
       Properties:
         Description: 'Cache Subnet Group'
         SubnetIds:
-        - Ref: ServerlessSubnetA
-        - Ref: ServerlessSubnetB
-        - Ref: ServerlessSubnetC
-    ServerlessElasticacheCluster:
-      DependsOn: ServerlessStorageSecurityGroup
+        - Ref: BertlySubnetA
+        - Ref: BertlySubnetB
+        - Ref: BertlySubnetC
+    BertlyElasticacheCluster:
+      DependsOn: BertlyStorageSecurityGroup
       Type: AWS::ElastiCache::CacheCluster
       Properties:
         Engine: redis
         NumCacheNodes: 1
         CacheNodeType: cache.r4.large
         VpcSecurityGroupIds:
-        - 'Fn::GetAtt': ServerlessStorageSecurityGroup.GroupId
+        - 'Fn::GetAtt': BertlyStorageSecurityGroup.GroupId
         CacheSubnetGroupName:
-          Ref: ServerlessElasticacheSubnetGroup
+          Ref: BertlyElasticacheSubnetGroup

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,13 @@ provider:
     REDIS_HOST: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Address" ] }
     REDIS_PORT: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Port" ] }
     BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}
+  vpc:
+    securityGroupIds:
+      - "Fn::GetAtt": ServerlessSecurityGroup.GroupId
+    subnetIds:
+      - Ref: ServerlessSubnetA
+      - Ref: ServerlessSubnetB
+      - Ref: ServerlessSubnetC
 
 functions:
   app:
@@ -49,13 +56,8 @@ functions:
     events:
       - http: ANY /
       - http: 'ANY {proxy+}'
-    vpc:
-      securityGroupIds:
-        - "Fn::GetAtt": ServerlessSecurityGroup.GroupId
-      subnetIds:
-        - Ref: ServerlessSubnetA
-        - Ref: ServerlessSubnetB
-        - Ref: ServerlessSubnetC
+  migrate:
+    handler: migrate.run
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,7 +52,7 @@ resources:
       Type: AWS::EC2::VPC
       Properties:
         CidrBlock: "10.0.0.0/16"
-    ServerlessSubnet:
+    ServerlessSubnetA:
       DependsOn: ServerlessVPC
       Type: AWS::EC2::Subnet
       Properties:
@@ -60,6 +60,22 @@ resources:
           Ref: ServerlessVPC
         AvailabilityZone: ${self:provider.region}a
         CidrBlock: "10.0.0.0/24"
+    ServerlessSubnetB:
+      DependsOn: ServerlessVPC
+      Type: AWS::EC2::Subnet
+      Properties:
+        VpcId:
+          Ref: ServerlessVPC
+        AvailabilityZone: ${self:provider.region}c
+        CidrBlock: "10.0.1.0/24"
+    ServerlessSubnetC:
+      DependsOn: ServerlessVPC
+      Type: AWS::EC2::Subnet
+      Properties:
+        VpcId:
+          Ref: ServerlessVPC
+        AvailabilityZone: ${self:provider.region}d
+        CidrBlock: "10.0.2.0/24"
     ServerlessSecurityGroup:
       DependsOn: ServerlessVPC
       Type: AWS::EC2::SecurityGroup
@@ -90,7 +106,9 @@ resources:
       Properties:
         DBSubnetGroupDescription: "RDS Subnet Group"
         SubnetIds:
-        - Ref: ServerlessSubnet
+        - Ref: ServerlessSubnetA
+        - Ref: ServerlessSubnetB
+        - Ref: ServerlessSubnetC
     ServerlessRDSCluster:
       DependsOn: ServerlessStorageSecurityGroup
       Type: AWS::RDS::DBInstance
@@ -109,7 +127,9 @@ resources:
       Properties:
         Description: "Cache Subnet Group"
         SubnetIds:
-        - Ref: ServerlessSubnet
+        - Ref: ServerlessSubnetA
+        - Ref: ServerlessSubnetB
+        - Ref: ServerlessSubnetC
     ServerlessElasticacheCluster:
       DependsOn: ServerlessStorageSecurityGroup
       Type: AWS::ElastiCache::CacheCluster

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,9 +18,9 @@ custom:
   customDomain:
     domainName: dosome.click
     basePath: ''
-    stage: ${self:provider.stage}
+    stage: ${opt:stage}
     createRoute53Record: true
-    enabled: ${self:custom.domainEnabled.${opt:stage, self:provider.stage}}
+    enabled: ${self:custom.domainEnabled.${opt:stage}}
 
 package:
   exclude:
@@ -30,12 +30,11 @@ package:
 provider:
   name: aws
   runtime: python2.7
-  stage: dev
   region: us-east-1
   environment:
-    BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}
-    POSTGRESQL_USER: ${ssm:/bertly/dev/postgres-user}
-    POSTGRESQL_PASSWORD: ${ssm:/bertly/dev/postgres-password~true}
+    BERTLY_API_KEY: ${ssm:/bertly/${opt:stage}/api-key~true}
+    POSTGRESQL_USER: ${ssm:/bertly/${opt:stage}/postgres-user}
+    POSTGRESQL_PASSWORD: ${ssm:/bertly/${opt:stage}/postgres-password~true}
     POSTGRESQL_DB: 'bertly_clicks'
     POSTGRESQL_HOST:
       'Fn::GetAtt': [ServerlessRDSCluster, 'Endpoint.Address']
@@ -134,8 +133,8 @@ resources:
         DBName: 'bertly_clicks'
         AllocatedStorage: 10
         DBInstanceClass: db.t2.small
-        MasterUsername: ${ssm:/bertly/dev/postgres-user}
-        MasterUserPassword: ${ssm:/bertly/dev/postgres-password~true}
+        MasterUsername: ${ssm:/bertly/${opt:stage}/postgres-user}
+        MasterUserPassword: ${ssm:/bertly/${opt:stage}/postgres-password~true}
         VPCSecurityGroups:
         - 'Fn::GetAtt': ServerlessStorageSecurityGroup.GroupId
         DBSubnetGroupName:

--- a/serverless.yml
+++ b/serverless.yml
@@ -105,8 +105,8 @@ resources:
           SourceSecurityGroupId:
             Ref: ServerlessSecurityGroup
         - IpProtocol: tcp
-          FromPort: '11211'
-          ToPort: '11211'
+          FromPort: '6379'
+          ToPort: '6379'
           SourceSecurityGroupId:
             Ref: ServerlessSecurityGroup
     ServerlessRDSSubnetGroup:

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,8 +34,8 @@ provider:
   stage: dev
   region: us-east-1
   environment:
-    POSTGRES_HOST: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Address" ] }
-    POSTGRES_PORT: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Port" ] }
+    POSTGRESQL_HOST: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Address" ] }
+    POSTGRESQL_PORT: { "Fn::GetAtt": [ ServerlessRDSCluster, "Endpoint.Port" ] }
     REDIS_HOST: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Address" ] }
     REDIS_PORT: { "Fn::GetAtt": [ ServerlessElasticacheCluster, "RedisEndpoint.Port" ] }
     BERTLY_API_KEY: ${ssm:/bertly/dev/api-key~true}

--- a/serverless.yml
+++ b/serverless.yml
@@ -46,6 +46,13 @@ functions:
     events:
       - http: ANY /
       - http: 'ANY {proxy+}'
+    vpc:
+      securityGroupIds:
+        - "Fn::GetAtt": ServerlessSecurityGroup.GroupId
+      subnetIds:
+        - Ref: ServerlessSubnetA
+        - Ref: ServerlessSubnetB
+        - Ref: ServerlessSubnetC
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -118,6 +118,8 @@ resources:
         DBName: 'bertly_clicks'
         AllocatedStorage: 10
         DBInstanceClass: db.t2.small
+        MasterUsername: ${ssm:/bertly/dev/postgres-user}
+        MasterUserPassword: ${ssm:/bertly/dev/postgres-password~true}
         VPCSecurityGroups:
         - "Fn::GetAtt": ServerlessStorageSecurityGroup.GroupId
         DBSubnetGroupName:


### PR DESCRIPTION
Right now we still provision resources manually (and don't have a VPC set up on the development organization, so we weren't able to hook up to the ElastiCache & RDS instances we'd made there). Ideally, we want [CloudFormation](https://aws.amazon.com/cloudformation/) to handle this for us so that we can feel confident that we have the same environment everywhere!

This pull request is a work-in-progress to see whether we can set that up without too much trouble, and by doing so hopefully get a functional development environment for #21. :v: The work so far takes some heavy inspiration from [this Serverless example](https://github.com/mugglmenzel/serverless-examples-cached-rds-ws/blob/master/serverless.yml) (found via the official [examples repo](https://github.com/serverless/examples)).