### PR TITLE
Provision new production Bertly environment.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -34,6 +34,7 @@ provider:
   region: us-east-1
   environment:
     BERTLY_API_KEY: ${ssm:/bertly/${opt:stage}/api-key~true}
+    COMPOSE_REDIS_URL: ${ssm:/bertly/${opt:stage}/redis-url~true}
     POSTGRESQL_USER: ${ssm:/bertly/${opt:stage}/postgres-user}
     POSTGRESQL_PASSWORD: ${ssm:/bertly/${opt:stage}/postgres-password~true}
     POSTGRESQL_DB: 'bertly_clicks'
@@ -41,10 +42,6 @@ provider:
       'Fn::GetAtt': [BertlyRDSCluster, 'Endpoint.Address']
     POSTGRESQL_PORT:
       'Fn::GetAtt': [BertlyRDSCluster, 'Endpoint.Port']
-    REDIS_HOST:
-      'Fn::GetAtt': [BertlyElasticacheCluster, 'RedisEndpoint.Address']
-    REDIS_PORT:
-      'Fn::GetAtt': [BertlyElasticacheCluster, 'RedisEndpoint.Port']
   vpc:
     securityGroupIds:
       - 'Fn::GetAtt': BertlySecurityGroup.GroupId
@@ -140,26 +137,3 @@ resources:
         - 'Fn::GetAtt': BertlyStorageSecurityGroup.GroupId
         DBSubnetGroupName:
           Ref: BertlyRDSSubnetGroup
-    BertlyElasticacheSubnetGroup:
-      Type: AWS::ElastiCache::SubnetGroup
-      Properties:
-        Description: 'Cache Subnet Group'
-        SubnetIds:
-        - Ref: BertlySubnetA
-        - Ref: BertlySubnetB
-        - Ref: BertlySubnetC
-    BertlyElasticacheCluster:
-      DependsOn: BertlyStorageSecurityGroup
-      Type: AWS::ElastiCache::CacheCluster
-      Properties:
-        Engine: redis
-        NumCacheNodes: 1
-        CacheNodeType: cache.r4.large
-        SnapshotRetentionLimit: 14 # Keep backups for 2 weeks.
-        SnapshotWindow: '04:00-08:00' # 12AM-4AM EST
-        SnapshotArns:
-          - ${ssm:/bertly/${opt:stage}/redis-snapshot}
-        VpcSecurityGroupIds:
-        - 'Fn::GetAtt': BertlyStorageSecurityGroup.GroupId
-        CacheSubnetGroupName:
-          Ref: BertlyElasticacheSubnetGroup

--- a/serverless.yml
+++ b/serverless.yml
@@ -46,9 +46,6 @@ provider:
     securityGroupIds:
       - 'Fn::GetAtt': BertlySecurityGroup.GroupId
     subnetIds:
-      - Ref: BertlyRDSSubnetA
-      - Ref: BertlyRDSSubnetB
-      - Ref: BertlyRDSSubnetC
       - Ref: BertlyPrivateSubnetA
 
 functions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -46,9 +46,10 @@ provider:
     securityGroupIds:
       - 'Fn::GetAtt': BertlySecurityGroup.GroupId
     subnetIds:
-      - Ref: BertlySubnetA
-      - Ref: BertlySubnetB
-      - Ref: BertlySubnetC
+      - Ref: BertlyRDSSubnetA
+      - Ref: BertlyRDSSubnetB
+      - Ref: BertlyRDSSubnetC
+      - Ref: BertlyPrivateSubnetA
 
 functions:
   app:
@@ -65,7 +66,69 @@ resources:
       Type: AWS::EC2::VPC
       Properties:
         CidrBlock: '10.0.0.0/16'
-    BertlySubnetA:
+    BertlyElasticIpLambda:
+      Type: AWS::EC2::EIP
+      Properties:
+        Domain: vpc
+    BertlyInternetGatewayLambda:
+      Type: AWS::EC2::InternetGateway
+    BertlyVPCGatewayAttachmentLambda:
+      Type: AWS::EC2::VPCGatewayAttachment
+      Properties:
+        VpcId:
+          Ref: BertlyVPC
+        InternetGatewayId:
+          Ref: BertlyInternetGatewayLambda
+    BertlyNatGatewayLambda:
+      Type: AWS::EC2::NatGateway
+      Properties:
+        AllocationId:
+          Fn::GetAtt:
+            - BertlyElasticIpLambda
+            - AllocationId
+        SubnetId:
+          Ref: BertlyPublicSubnetA
+    BertlyPrivateRouteTable:
+      Type: AWS::EC2::RouteTable
+      Properties:
+        VpcId:
+          Ref: BertlyVPC 
+    BertlyPrivateRoute:
+      Type: AWS::EC2::Route
+      Properties:
+        RouteTableId:
+          Ref: BertlyPrivateRouteTable
+        DestinationCidrBlock: 0.0.0.0/0
+        NatGatewayId:
+          Ref: BertlyNatGatewayLambda
+    BertlyPublicRouteTable:
+      Type: AWS::EC2::RouteTable
+      Properties:
+        VpcId:
+          Ref: BertlyVPC
+    BertlyPublicRoute:
+      Type: AWS::EC2::Route
+      Properties:
+        RouteTableId:
+          Ref: BertlyPublicRouteTable
+        DestinationCidrBlock: 0.0.0.0/0
+        GatewayId:
+          Ref: BertlyInternetGatewayLambda
+    SubnetRouteTableAssociationLambdaPrivateA:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        SubnetId:
+          Ref: BertlyPrivateSubnetA
+        RouteTableId:
+          Ref: BertlyPrivateRouteTable
+    SubnetRouteTableAssociationLambdaPublicA:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        SubnetId:
+          Ref: BertlyPublicSubnetA
+        RouteTableId:
+          Ref: BertlyPublicRouteTable
+    BertlyRDSSubnetA:
       DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
@@ -73,7 +136,7 @@ resources:
           Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}a
         CidrBlock: '10.0.0.0/24'
-    BertlySubnetB:
+    BertlyRDSSubnetB:
       DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
@@ -81,7 +144,7 @@ resources:
           Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}c
         CidrBlock: '10.0.1.0/24'
-    BertlySubnetC:
+    BertlyRDSSubnetC:
       DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
@@ -89,6 +152,22 @@ resources:
           Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}d
         CidrBlock: '10.0.2.0/24'
+    BertlyPublicSubnetA:
+      DependsOn: BertlyVPC
+      Type: AWS::EC2::Subnet
+      Properties:
+        VpcId:
+          Ref: BertlyVPC
+        AvailabilityZone: ${self:provider.region}d
+        CidrBlock: '10.0.3.0/24'
+    BertlyPrivateSubnetA:
+      DependsOn: BertlyVPC
+      Type: AWS::EC2::Subnet
+      Properties:
+        VpcId:
+          Ref: BertlyVPC
+        AvailabilityZone: ${self:provider.region}d
+        CidrBlock: '10.0.4.0/24'
     BertlySecurityGroup:
       DependsOn: BertlyVPC
       Type: AWS::EC2::SecurityGroup
@@ -105,13 +184,9 @@ resources:
           Ref: BertlyVPC
         SecurityGroupIngress:
         - IpProtocol: tcp
+          Description: 'Allow access to RDS Postgres database.'
           FromPort: '5432'
           ToPort: '5432'
-          SourceSecurityGroupId:
-            Ref: BertlySecurityGroup
-        - IpProtocol: tcp
-          FromPort: '6379'
-          ToPort: '6379'
           SourceSecurityGroupId:
             Ref: BertlySecurityGroup
     BertlyRDSSubnetGroup:
@@ -119,9 +194,9 @@ resources:
       Properties:
         DBSubnetGroupDescription: 'RDS Subnet Group'
         SubnetIds:
-        - Ref: BertlySubnetA
-        - Ref: BertlySubnetB
-        - Ref: BertlySubnetC
+        - Ref: BertlyRDSSubnetA
+        - Ref: BertlyRDSSubnetB
+        - Ref: BertlyRDSSubnetC
     BertlyRDSCluster:
       DependsOn: BertlyStorageSecurityGroup
       Type: AWS::RDS::DBInstance

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,8 @@ custom:
     basePath: ''
     stage: ${opt:stage}
     createRoute53Record: true
-    enabled: ${self:custom.domainEnabled.${opt:stage}}
+    enabled: false
+    # enabled: ${self:custom.domainEnabled.${opt:stage}}
 
 package:
   exclude:

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,24 +63,37 @@ resources:
       Type: AWS::EC2::VPC
       Properties:
         CidrBlock: '10.0.0.0/16'
-    BertlyElasticIpLambda:
+    BertlyElasticIp:
       Type: AWS::EC2::EIP
       Properties:
         Domain: vpc
-    BertlyInternetGatewayLambda:
+    BertlyInternetGateway:
       Type: AWS::EC2::InternetGateway
-    BertlyVPCGatewayAttachmentLambda:
+    BertlyVPCGatewayAttachment:
       Type: AWS::EC2::VPCGatewayAttachment
       Properties:
         VpcId:
           Ref: BertlyVPC
         InternetGatewayId:
-          Ref: BertlyInternetGatewayLambda
-    BertlyNatGatewayLambda:
+          Ref: BertlyInternetGateway
+    BertlyPublicRouteTable:
+      Type: AWS::EC2::RouteTable
+      Properties:
+        VpcId:
+          Ref: BertlyVPC
+    BertlyPublicRoute:
+      Type: AWS::EC2::Route
+      Properties:
+        RouteTableId:
+          Ref: BertlyPublicRouteTable
+        DestinationCidrBlock: 0.0.0.0/0
+        GatewayId:
+          Ref: BertlyInternetGateway
+    BertlyNatGateway:
       Type: AWS::EC2::NatGateway
       Properties:
         AllocationId:
-          Fn::GetAtt: BertlyElasticIpLambda.AllocationId
+          Fn::GetAtt: BertlyElasticIp.AllocationId
         SubnetId:
           Ref: BertlyPublicSubnetA
     BertlyPrivateRouteTable:
@@ -95,74 +108,45 @@ resources:
           Ref: BertlyPrivateRouteTable
         DestinationCidrBlock: 0.0.0.0/0
         NatGatewayId:
-          Ref: BertlyNatGatewayLambda
-    BertlyPublicRouteTable:
-      Type: AWS::EC2::RouteTable
-      Properties:
-        VpcId:
-          Ref: BertlyVPC
-    BertlyPublicRoute:
-      Type: AWS::EC2::Route
-      Properties:
-        RouteTableId:
-          Ref: BertlyPublicRouteTable
-        DestinationCidrBlock: 0.0.0.0/0
-        GatewayId:
-          Ref: BertlyInternetGatewayLambda
-    SubnetRouteTableAssociationLambdaPrivateA:
-      Type: AWS::EC2::SubnetRouteTableAssociation
-      Properties:
-        SubnetId:
-          Ref: BertlyPrivateSubnetA
-        RouteTableId:
-          Ref: BertlyPrivateRouteTable
-    SubnetRouteTableAssociationLambdaPublicA:
+          Ref: BertlyNatGateway
+    BertlySubnetRouteTableAssociationPublicA:
       Type: AWS::EC2::SubnetRouteTableAssociation
       Properties:
         SubnetId:
           Ref: BertlyPublicSubnetA
         RouteTableId:
           Ref: BertlyPublicRouteTable
-    BertlyRDSSubnetA:
-      DependsOn: BertlyVPC
-      Type: AWS::EC2::Subnet
-      Properties:
-        VpcId:
-          Ref: BertlyVPC
-        AvailabilityZone: ${self:provider.region}a
-        CidrBlock: '10.0.0.0/24'
-    BertlyRDSSubnetB:
-      DependsOn: BertlyVPC
-      Type: AWS::EC2::Subnet
-      Properties:
-        VpcId:
-          Ref: BertlyVPC
-        AvailabilityZone: ${self:provider.region}c
-        CidrBlock: '10.0.1.0/24'
-    BertlyRDSSubnetC:
-      DependsOn: BertlyVPC
-      Type: AWS::EC2::Subnet
-      Properties:
-        VpcId:
-          Ref: BertlyVPC
-        AvailabilityZone: ${self:provider.region}d
-        CidrBlock: '10.0.2.0/24'
     BertlyPublicSubnetA:
       DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
         VpcId:
           Ref: BertlyVPC
-        AvailabilityZone: ${self:provider.region}d
-        CidrBlock: '10.0.3.0/24'
+        AvailabilityZone: ${self:provider.region}a
+        CidrBlock: '10.0.1.0/24'
+    BertlySubnetRouteTableAssociationPrivateA:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        SubnetId:
+          Ref: BertlyPrivateSubnetA
+        RouteTableId:
+          Ref: BertlyPrivateRouteTable
     BertlyPrivateSubnetA:
       DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet
       Properties:
         VpcId:
           Ref: BertlyVPC
-        AvailabilityZone: ${self:provider.region}d
-        CidrBlock: '10.0.4.0/24'
+        AvailabilityZone: ${self:provider.region}a
+        CidrBlock: '10.0.2.0/24'
+    BertlyPrivateSubnetB:
+      DependsOn: BertlyVPC
+      Type: AWS::EC2::Subnet
+      Properties:
+        VpcId:
+          Ref: BertlyVPC
+        AvailabilityZone: ${self:provider.region}b
+        CidrBlock: '10.0.3.0/24'
     BertlySecurityGroup:
       DependsOn: BertlyVPC
       Type: AWS::EC2::SecurityGroup
@@ -189,9 +173,8 @@ resources:
       Properties:
         DBSubnetGroupDescription: 'RDS Subnet Group'
         SubnetIds:
-        - Ref: BertlyRDSSubnetA
-        - Ref: BertlyRDSSubnetB
-        - Ref: BertlyRDSSubnetC
+        - Ref: BertlyPrivateSubnetA
+        - Ref: BertlyPrivateSubnetB
     BertlyRDSCluster:
       DependsOn: BertlyStorageSecurityGroup
       Type: AWS::RDS::DBInstance

--- a/serverless.yml
+++ b/serverless.yml
@@ -155,6 +155,8 @@ resources:
         Engine: redis
         NumCacheNodes: 1
         CacheNodeType: cache.r4.large
+        SnapshotRetentionLimit: 14 # Keep backups for 2 weeks.
+        SnapshotWindow: '04:00-08:00' # 12AM-4AM EST
         SnapshotArns:
           - ${ssm:/bertly/${opt:stage}/redis-snapshot}
         VpcSecurityGroupIds:

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,12 +39,12 @@ provider:
     POSTGRESQL_PASSWORD: ${ssm:/bertly/${opt:stage}/postgres-password~true}
     POSTGRESQL_DB: 'bertly_clicks'
     POSTGRESQL_HOST:
-      'Fn::GetAtt': [BertlyRDSCluster, 'Endpoint.Address']
+      Fn::GetAtt: [BertlyRDSCluster, 'Endpoint.Address']
     POSTGRESQL_PORT:
-      'Fn::GetAtt': [BertlyRDSCluster, 'Endpoint.Port']
+      Fn::GetAtt: [BertlyRDSCluster, 'Endpoint.Port']
   vpc:
     securityGroupIds:
-      - 'Fn::GetAtt': BertlySecurityGroup.GroupId
+      - Fn::GetAtt: BertlySecurityGroup.GroupId
     subnetIds:
       - Ref: BertlyPrivateSubnetA
 
@@ -80,9 +80,7 @@ resources:
       Type: AWS::EC2::NatGateway
       Properties:
         AllocationId:
-          Fn::GetAtt:
-            - BertlyElasticIpLambda
-            - AllocationId
+          Fn::GetAtt: BertlyElasticIpLambda.AllocationId
         SubnetId:
           Ref: BertlyPublicSubnetA
     BertlyPrivateRouteTable:
@@ -206,6 +204,6 @@ resources:
         MasterUsername: ${ssm:/bertly/${opt:stage}/postgres-user}
         MasterUserPassword: ${ssm:/bertly/${opt:stage}/postgres-password~true}
         VPCSecurityGroups:
-        - 'Fn::GetAtt': BertlyStorageSecurityGroup.GroupId
+        - Fn::GetAtt: BertlyStorageSecurityGroup.GroupId
         DBSubnetGroupName:
           Ref: BertlyRDSSubnetGroup

--- a/serverless.yml
+++ b/serverless.yml
@@ -155,6 +155,8 @@ resources:
         Engine: redis
         NumCacheNodes: 1
         CacheNodeType: cache.r4.large
+        SnapshotArns:
+          - ${ssm:/bertly/${opt:stage}/redis-snapshot}
         VpcSecurityGroupIds:
         - 'Fn::GetAtt': BertlyStorageSecurityGroup.GroupId
         CacheSubnetGroupName:


### PR DESCRIPTION
This pull request does some prep-work to create and then migrate to a new production Bertly stack (since we're currently running traffic off of the older `bertly-dev-app` stack in our prod organization).