### PR TITLE
Updating values to reflect Prod environment.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -131,8 +131,8 @@ resources:
         Engine: Postgres 
         EngineVersion: '10.3'
         DBName: 'bertly_clicks'
-        AllocatedStorage: 10
-        DBInstanceClass: db.t2.small
+        AllocatedStorage: 100
+        DBInstanceClass: db.t2.medium
         MasterUsername: ${ssm:/bertly/${opt:stage}/postgres-user}
         MasterUserPassword: ${ssm:/bertly/${opt:stage}/postgres-password~true}
         VPCSecurityGroups:


### PR DESCRIPTION
A while back I upped the Production Bertly DB values to allow for enough disk IOPS and CPU usage for more spikes, as well as being able to accommodate real-time DB replication into Quasar.

I've updated the CloudFormation parts of the `serverless.yml` provisioning to reflect these changes. 

Diff here: https://github.com/DoSomething/bertly/compare/rds-size?expand=1#diff-220045f50daee3e35e21b9d5fe19d67e