### PR TITLE
Add user agent column to clicks table.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -159,7 +159,7 @@ def bounce(key):
     # Grab user-agent, or string 'None' if not provided.
     ua = request.headers.get('User-Agent')
     if ua is None:
-        ua = 'None' 
+        ua = 'None'
 
     # Record new click. See models.py for data definition
     click = Click(click_id=uuid4(), click_time=datetime.utcnow(),

--- a/bertly.py
+++ b/bertly.py
@@ -156,9 +156,14 @@ def bounce(key):
     if url is None:
         abort(404)
 
+    # Grab user-agent, or string 'None' if not provided.
+    ua = request.headers.get('User-Agent')
+    if ua is None:
+        ua = 'None' 
+
     # Record new click. See models.py for data definition
     click = Click(click_id=uuid4(), click_time=datetime.utcnow(),
-                  shortened=key, target_url=url)
+                  shortened=key, target_url=url, user_agent=ua[:255])
     db.session.add(click)
     db.session.commit()
 

--- a/migrations/versions/6a06ce83dde2_add_user_agent_column.py
+++ b/migrations/versions/6a06ce83dde2_add_user_agent_column.py
@@ -1,0 +1,24 @@
+"""Add user agent column.
+
+Revision ID: 6a06ce83dde2
+Revises: 42a810a76302
+Create Date: 2018-07-12 13:48:00.527162
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6a06ce83dde2'
+down_revision = '42a810a76302'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('clicks', sa.Column('user_agent', sa.String(255)))
+
+
+def downgrade():
+    op.drop_column('clicks', 'user_agent')


### PR DESCRIPTION
This pull request adds a `user_agent` column to the clicks table, so we can keep track of where clicks are coming from and potentially filter out non-user sources, like iMessage previews or other crawlers.

Since it seems like some user agent strings can potentially be [quite long](https://stackoverflow.com/questions/654921/how-big-can-a-user-agent-string-get), I've truncated values placed in this column to 255 characters, which is more than enough for the Facebook/Twitter/iMessage user agent we're looking to filter and most other "normal" values.

References #37.