### PR TITLE
Add private route table association to Subnet B.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -163,7 +163,7 @@ def bounce(key):
 
     # Record new click. See models.py for data definition
     click = Click(click_id=uuid4(), click_time=datetime.utcnow(),
-                  shortened=key, target_url=url) # , user_agent=ua[:255]
+                  shortened=key, target_url=url)  # , user_agent=ua[:255]
     db.session.add(click)
     db.session.commit()
 

--- a/bertly.py
+++ b/bertly.py
@@ -163,7 +163,7 @@ def bounce(key):
 
     # Record new click. See models.py for data definition
     click = Click(click_id=uuid4(), click_time=datetime.utcnow(),
-                  shortened=key, target_url=url, user_agent=ua[:255])
+                  shortened=key, target_url=url) # , user_agent=ua[:255]
     db.session.add(click)
     db.session.commit()
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -139,6 +139,13 @@ resources:
           Ref: BertlyVPC
         AvailabilityZone: ${self:provider.region}a
         CidrBlock: '10.0.2.0/24'
+    BertlySubnetRouteTableAssociationPrivateB:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        SubnetId:
+          Ref: BertlyPrivateSubnetB
+        RouteTableId:
+          Ref: BertlyPrivateRouteTable
     BertlyPrivateSubnetB:
       DependsOn: BertlyVPC
       Type: AWS::EC2::Subnet


### PR DESCRIPTION
This pull request adds a private route table association to `BertlyPrivateSubnetB` so it doesn't default to the main one and bork things up. Tested & deployed to new production instance in our working sesh.

References #21.