### PR TITLE
Add parameter group to CloudFormation template.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -181,6 +181,14 @@ resources:
         SubnetIds:
         - Ref: BertlyPrivateSubnetA
         - Ref: BertlyPrivateSubnetB
+    BertlyQuasarDBParameterGroup:
+      Type: AWS::RDS::DBParameterGroup
+      Properties:
+        Description: 'Allow logical replication from Bertly to Quasar.'
+        Family: 'postgres10'
+        Parameters:
+          max_logical_replication_workers: 500
+          rds.logical_replication: 1
     BertlyRDSCluster:
       DependsOn: BertlyStorageSecurityGroup
       Type: AWS::RDS::DBInstance
@@ -196,4 +204,5 @@ resources:
         - Fn::GetAtt: BertlyStorageSecurityGroup.GroupId
         DBSubnetGroupName:
           Ref: BertlyRDSSubnetGroup
-        DBParameterGroupName: 'postgres10-repl'
+        DBParameterGroupName:
+          Ref: BertlyQuasarDBParameterGroup


### PR DESCRIPTION
This pull request fixes #42 by adding a `BertlyQuasarDBParameterGroup` with the same parameters that we'd added to the hand-crafted `postgres10-repl` parameter group. This unblocks deploys to dev & QA Bertly instances, where this `postgres10-repl` parameter group does not exist.