### PR TITLE
Quick bandaid for timeout issues during broadcasts.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -55,8 +55,8 @@ redis_client = redis.StrictRedis(
     password=parsed.password,
     ssl=ssl_wanted,
     decode_responses=True,
-    socket_connect_timeout=1.0,
-    socket_timeout=1.0)
+    socket_connect_timeout=5.0,
+    socket_timeout=5.0)
 
 # Configure PostgreSQL/SQLAlchemy connection:
 app.config['SQLALCHEMY_DATABASE_URI'] = config.POSTGRES_URL

--- a/serverless.yml
+++ b/serverless.yml
@@ -53,6 +53,7 @@ provider:
 functions:
   app:
     handler: wsgi.handler
+    timeout: 15
     events:
       - http: ANY /
       - http: 'ANY {proxy+}'


### PR DESCRIPTION
This pull request includes a quick bandaid for timeout issues during broadcasts. Bert's been getting more 500s during the past few broadcasts, as originally flagged by @rapala61 [in Slack](https://dosomething.slack.com/archives/CAX6AJSF2/p1548969492000400):

```
TimeoutError: Timeout reading from socket
```

These are due [to a timeout connecting to the Redis instance](https://github.com/andymccurdy/redis-py/blob/5a2e26d2b0b554bfcd6875a968bcd8090b7f9b03/redis/connection.py#L193-L194). As a quick fix, I've bumped our Redis `socket_timeout` and `socket_connect_timeout`, and increased the overall Lambda function timeout to compensate for the potential added time.