### PR TITLE
Two lil' Bertly touch-ups.

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -144,7 +144,7 @@ def shorten():
     url = url_for('bounce', key=key, _external=True)
     revoke = url_for('revoke', key=key, _external=True)
 
-    return jsonify({'url': url, 'revoke': revoke})
+    return jsonify({'id': url,  'url': url, 'revoke': revoke})
 
 
 # ROUTE: GET /<key>

--- a/bertly.py
+++ b/bertly.py
@@ -100,7 +100,7 @@ def jsonify(obj, status_code=200):
 
 def valid_url(url):
     parsed = urlparse(url)
-    return all([parsed.scheme, parsed.netloc, parsed.path])
+    return all([parsed.scheme, parsed.netloc])
 
 def require_api_key(view_function):
     """Decorator to require API key in header, passed as api_key_label"""

--- a/bertly.py
+++ b/bertly.py
@@ -99,8 +99,8 @@ def jsonify(obj, status_code=200):
 
 
 def valid_url(url):
-    return bool(parse(url, rule='URI_reference'))
-
+    parsed = urlparse(url)
+    return all([parsed.scheme, parsed.netloc, parsed.path])
 
 def require_api_key(view_function):
     """Decorator to require API key in header, passed as api_key_label"""
@@ -138,7 +138,7 @@ def shorten():
     url = request.form['url'].strip()
 
     if not valid_url(url):
-        return jsonify({'error': str(e)}, 400)
+        return jsonify({'error': 'Invalid URL.'}, 400)
 
     key = get_key_for_url(url)
     url = url_for('bounce', key=key, _external=True)


### PR DESCRIPTION
This pull request adds [an `id` field](https://shortmenu.com/support/custom-services/#responses) to the response, so I can use my [favorite little Mac app](https://shortmenu.com/mac/) to shorten a bunch of Bertly links for the Prom campaign. I've also fixed some fatal errors that were getting thrown on invalid URLs. 💣