### PR TITLE
Updating Jinja2 to mitigate high-severity vuln.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.3.2
 futures==3.2.0
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2>=2.10.1
 jmespath==0.9.3
 Mako==1.0.7
 MarkupSafe==1.0


### PR DESCRIPTION
Updates Jinja2 package to version that patches a [high security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-10906). 