### PR TITLE
Update SQLAlchemy to address CVE-2019-7164 and CVE-2019-7548.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ rq==0.10.0
 s3transfer==0.1.13
 short-url==1.2.2
 six==1.11.0
-SQLAlchemy==1.2.7
+SQLAlchemy==1.3.3
 url-normalize==1.3.3
 Werkzeug==0.12.2


### PR DESCRIPTION
This pull request updates SQLAlchemy to address [CVE-2019-7164](https://nvd.nist.gov/vuln/detail/CVE-2019-7164) and [CVE-2019-7548](https://nvd.nist.gov/vuln/detail/CVE-2019-7548). Luckily, we don't accept user input into `order_by` or `group_by` in this app (or in fact use them at all).