### PR TITLE
Update PostgreSQL version for clicks database.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -200,7 +200,7 @@ resources:
       Type: AWS::RDS::DBInstance
       Properties:
         Engine: Postgres 
-        EngineVersion: '10.3'
+        EngineVersion: '10.9'
         DBName: 'bertly_clicks'
         AllocatedStorage: 100
         DBInstanceClass: db.t2.medium


### PR DESCRIPTION
This pull request updates Bertly's PostgreSQL database to the latest 10.x minor version.

References [#167181749](https://www.pivotaltracker.com/story/show/167181749).