### PR TITLE
Add Link model & "create link" endpoint.

### DIFF
--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -44,11 +44,11 @@ export default async function createLink(req, res) {
 
   // Find & return already shortened link, if one exists.
   const result = await Link.query({ url }).limit(1).exec();
-  const existing = result.count ? result[0] : null;
-  if (existing) {
-    info('Found matching shortlink', pick(existing, ['key', 'url']));
+  const existingLink = result.count ? result[0] : null;
+  if (existingLink) {
+    info('Found shortlink', pick(existingLink, ['key', 'url']));
 
-    return res.json(existing);
+    return res.json(existingLink);
   }
 
   // If we haven't yet shortened this URL, make new shortlink:

--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -1,0 +1,61 @@
+import { pick } from 'lodash';
+import HashId from 'hashids/cjs';
+import { info } from 'heroku-logger';
+import * as Express from 'express';
+
+import config from '../../config';
+import Link from '../Models/Link';
+import { randomChar } from '../helpers';
+
+/**
+ * Crete a new shortlink key.
+ *
+ * @return {String}
+ */
+async function generateKey() {
+  // In order to avoid a single "hot" key with our counter, we split
+  // the table into 3,844 partitions (e.g. AA, AB, AC...). Each partition
+  // keeps its own auto-incremented counter for making shortlinks, below:
+  const partition = await Link.update(
+    { key: `${randomChar()}${randomChar()}` },
+    { $ADD: { counter: 1 } }
+  );
+
+  // We can then use hashids <https://hashids.org> to generate short
+  // guaranteed unique IDs for each partition. (We pad these to be at
+  // least 5 characters long so these new keys won't conflict with
+  // Bertly 1.0's existing shortlinks).
+  const id = new HashId(config('app.secret'), 5);
+
+  // e.g. 'bSlejRe'
+  return `${partition.key}${id.encode(partition.counter)}`;
+}
+
+/**
+ * Create a new shortlink.
+ * POST /
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ */
+export default async function createLink(req, res) {
+  // TODO: Validate input and return a 422 for bad stuff.
+  const { url } = req.body;
+
+  // Find & return already shortened link, if one exists.
+  const result = await Link.query({ url }).limit(1).exec();
+  const existing = result.count ? result[0] : null;
+  if (existing) {
+    info('Found matching shortlink', pick(existing, ['key', 'url']));
+
+    return res.json(existing);
+  }
+
+  // If we haven't yet shortened this URL, make new shortlink:
+  const key = await generateKey();
+  const link = await Link.create({ key, url });
+
+  info('Created new shortlink', pick(link, ['key', 'url']));
+
+  return res.status(201).json(link);
+}

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -1,0 +1,31 @@
+/// <reference types="jest" />
+
+import Link from '../Models/Link';
+import { postJson } from '../testing';
+import { dropTable } from '../helpers';
+
+beforeEach(() => dropTable(Link));
+
+describe('createLink', () => {
+  test('It should create links', async () => {
+    const url = 'https://www.example.com';
+    const response = await postJson('/', { url });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toHaveProperty('key');
+    expect(response.body).toHaveProperty('url', url);
+  });
+
+  test('It should not create duplicate links', async () => {
+    const link = await Link.create({
+      key: 'xyz828f',
+      url: 'http://www.example.com',
+    });
+
+    const response = await postJson('/', { url: link.url });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('key', link.key);
+    expect(response.body).toHaveProperty('url', link.url);
+  });
+});

--- a/src/Models/Link.js
+++ b/src/Models/Link.js
@@ -1,0 +1,51 @@
+import { Schema, model } from 'dynamoose';
+
+import config from '../../config';
+
+// See: https://dynamoosejs.com/guide/Schema
+const schema = new Schema(
+  {
+    key: {
+      hashKey: true,
+      required: true,
+      type: String,
+    },
+    url: {
+      type: String,
+      required: true,
+      index: {
+        name: 'urlIndex',
+        global: true,
+      },
+    },
+    counter: {
+      type: Number,
+      default: 0,
+    },
+  },
+  // Automatically set 'createdAt' and 'updatedAt'
+  // fields on these records upon creation/update.
+  {
+    timestamps: true,
+  }
+);
+
+const options = {
+  // If we're running in development, wait for the local server to be started and
+  // automatically run a "migration" to create DynamoDB table if it doesn't exist.
+  // (We skip this on production instances since it has a performance impact).
+  create: ['development', 'test'].includes(process.env.NODE_ENV),
+  waitForActive: ['development', 'test'].includes(process.env.NODE_ENV),
+
+  // TODO: This seems to be bugged <...>. We should see if we can figure out what's
+  // going wrong here, and fix if possible so we can run "update" migrations.
+  update: false,
+
+  // We use 'ON_DEMAND' capacity for this table since load is so variable.
+  throughput: 'ON_DEMAND',
+
+  // Prefix DynamoDB tables with the application name.
+  prefix: `${config('app.name')}-`,
+};
+
+export default model('links', schema, options);

--- a/src/Models/Link.js
+++ b/src/Models/Link.js
@@ -37,8 +37,8 @@ const options = {
   create: ['development', 'test'].includes(process.env.NODE_ENV),
   waitForActive: ['development', 'test'].includes(process.env.NODE_ENV),
 
-  // TODO: This seems to be bugged <...>. We should see if we can figure out what's
-  // going wrong here, and fix if possible so we can run "update" migrations.
+  // TODO: This seems to be bugged <https://git.io/Jf401>. We should see if we
+  // can figure out what's going wrong here so we can run "update" migrations.
   update: false,
 
   // We use 'ON_DEMAND' capacity for this table since load is so variable.

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,9 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import asyncHandler from 'express-async-handler';
 
+import auth from './Middleware/auth';
 import notFound from './Middleware/notFound';
+import createLink from './Functions/createLink';
 import errorHandler from './Middleware/errorHandler';
 
 const app = express();
@@ -12,7 +14,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
 // Routes:
-// ...
+app.post('/', [auth], asyncHandler(createLink));
 
 // Attach terminal "not found" & error handler
 // middleware for when things go awry:

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -33,6 +33,23 @@ export function printRoute(method, path) {
 }
 
 /**
+ * Return a random alphanumeric character.
+ *
+ * @return {String}
+ */
+export function randomChar() {
+  const alphabet =
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+  // This *isn't* cryptographically secure, but we don't need it to be.
+  // Math.random will give us a uniform distribution of characters
+  // once N is large enough. See: https://git.io/JfcNa
+  const offset = Math.floor(Math.random() * alphabet.length);
+
+  return alphabet[offset];
+}
+
+/**
  * Drop the given database table.
  *
  * @return {Promise}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a "create link" endpoint, based on Bertly's [existing `POST /` endpoint](https://github.com/DoSomething/bertly/tree/master/documentation#create-short-link).

### How should this be reviewed?

I've added the [Dynamoose](https://dynamoosejs.com/getting_started/Introduction) (DynamoDB) model in 2919e2f. This sets up our database schema, indexes, and some database settings (could maybe extract if we ever add more models).

I then added the `POST /` endpoint & a functional test in 2371773. The most interesting thing here is how this creates unique short-links and partitions the counter to avoid a single "hot" key.

### Any background context you want to provide?

I still need to set up validation & authentication but will tackle that later on.

I'll push up PRs for the other endpoints once this is merged (since they need `Link` too).

### Relevant tickets

References [Pivotal #172799437](https://www.pivotaltracker.com/story/show/172799437).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
