### PR TITLE
Add "visit link" route.

### DIFF
--- a/src/Functions/visitLink.js
+++ b/src/Functions/visitLink.js
@@ -1,0 +1,26 @@
+import * as Express from 'express';
+
+import Link from '../Models/Link';
+import NotFoundException from '../Exceptions/NotFoundException';
+
+/**
+ * Visit a shortlink.
+ * GET /{link}
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ */
+export default async function visitLink(req, res) {
+  const link = await Link.get(req.params.link);
+
+  if (!link) {
+    throw new NotFoundException('Not found.');
+  }
+
+  // Increment this link's counter:
+  Link.update({ key: link.key }, { $ADD: { counter: 1 } });
+
+  // TODO: Log this "click" to our storage bucket.
+
+  return res.redirect(link.url);
+}

--- a/src/Functions/visitLink.spec.js
+++ b/src/Functions/visitLink.spec.js
@@ -1,0 +1,25 @@
+/// <reference types="jest" />
+
+import { visit } from '../testing';
+import Link from '../Models/Link';
+import { dropTable } from '../helpers';
+
+beforeEach(() => dropTable(Link));
+
+describe('visitLink', () => {
+  test('It should redirect', async () => {
+    await Link.create({ key: 'xyz828f', url: 'http://vote.dosomething.org' });
+
+    const response = await visit(`/xyz828f`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('http://vote.dosomething.org');
+  });
+
+  test('It should handle missing links', async () => {
+    const response = await visit(`/xyz123/info`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('http://www.dosomething.org/404');
+  });
+});

--- a/src/Functions/visitLink.spec.js
+++ b/src/Functions/visitLink.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 
-import { visit } from '../testing';
 import Link from '../Models/Link';
+import { visit } from '../testing';
 import { dropTable } from '../helpers';
 
 beforeEach(() => dropTable(Link));

--- a/src/Functions/visitLink.spec.js
+++ b/src/Functions/visitLink.spec.js
@@ -17,7 +17,7 @@ describe('visitLink', () => {
   });
 
   test('It should handle missing links', async () => {
-    const response = await visit(`/xyz123/info`);
+    const response = await visit(`/xyz123`);
 
     expect(response.status).toBe(302);
     expect(response.headers.location).toBe('http://www.dosomething.org/404');

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import asyncHandler from 'express-async-handler';
 
 import auth from './Middleware/auth';
 import notFound from './Middleware/notFound';
+import visitLink from './Functions/visitLink';
 import createLink from './Functions/createLink';
 import errorHandler from './Middleware/errorHandler';
 
@@ -15,6 +16,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 
 // Routes:
 app.post('/', [auth], asyncHandler(createLink));
+app.get('/:link', asyncHandler(visitLink));
 
 // Attach terminal "not found" & error handler
 // middleware for when things go awry:


### PR DESCRIPTION
### What's this PR do?

This pull request adds the ability to visit short-links – Bert's specialty!! This reads the `Link` record we created in #59, and either returns a 302 to the destination URL or throws a "not found" exception if we haven't made that short-link yet.

### How should this be reviewed?

This should be a quick one! Just the route & the test! 🚥

### Any background context you want to provide?

The next step will be saving some information about the request (destination, user-agent, yadda yadda) into our S3 storage bucket. I'll tackle that in a follow-up pull request.

### Relevant tickets

References [Pivotal #172799447](https://www.pivotaltracker.com/story/show/172799447).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
