### PR TITLE
Add "inspect link" route.

### DIFF
--- a/src/Functions/inspectLink.js
+++ b/src/Functions/inspectLink.js
@@ -1,0 +1,21 @@
+import * as Express from 'express';
+
+import Link from '../Models/Link';
+import NotFoundException from '../Exceptions/NotFoundException';
+
+/**
+ * Inspect a shortlink.
+ * GET /{link}/info
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ */
+export default async function inspectLink(req, res) {
+  const link = await Link.get(req.params.link);
+
+  if (!link) {
+    throw new NotFoundException('Not found');
+  }
+
+  return res.json(link);
+}

--- a/src/Functions/inspectLink.spec.js
+++ b/src/Functions/inspectLink.spec.js
@@ -1,0 +1,29 @@
+/// <reference types="jest" />
+
+import Link from '../Models/Link';
+import { getJson } from '../testing';
+import { dropTable } from '../helpers';
+
+beforeEach(() => dropTable(Link));
+
+describe('inspectLink', () => {
+  test('It should allow inspecting links', async () => {
+    const link = await Link.create({
+      key: 'xyz828f',
+      url: 'http://www.example.com',
+    });
+
+    const response = await getJson(`/${link.key}/info`).send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('key', link.key);
+    expect(response.body).toHaveProperty('url', link.url);
+    expect(response.body).toHaveProperty('counter');
+  });
+
+  test('It should handle missing links', async () => {
+    const response = await getJson(`/xyz123/info`);
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import asyncHandler from 'express-async-handler';
 import auth from './Middleware/auth';
 import notFound from './Middleware/notFound';
 import createLink from './Functions/createLink';
+import inspectLink from './Functions/inspectLink';
 import errorHandler from './Middleware/errorHandler';
 
 const app = express();
@@ -15,6 +16,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 
 // Routes:
 app.post('/', [auth], asyncHandler(createLink));
+app.get('/:link/info', asyncHandler(inspectLink));
 
 // Attach terminal "not found" & error handler
 // middleware for when things go awry:


### PR DESCRIPTION
### What's this PR do?

This pull request adds the ability to "inspect" links... which is basically just a dead-simple CRUD "show" endpoint. The only difference from visiting a link is that we don't count this as a click.

### How should this be reviewed?

Peep the route & the test! 🚥

### Any background context you want to provide?

🕵️ 

### Relevant tickets

References [Pivotal #172799445](https://www.pivotaltracker.com/story/show/172799445).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
