### PR TITLE
Add "destroy link" route.

### DIFF
--- a/src/Functions/destroyLink.js
+++ b/src/Functions/destroyLink.js
@@ -1,0 +1,23 @@
+import * as Express from 'express';
+
+import Link from '../Models/Link';
+import NotFoundException from '../Exceptions/NotFoundException';
+
+/**
+ * Destroy a shortlink.
+ * DELETE /{link}
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ */
+export default async function destroyLink(req, res) {
+  const link = await Link.get(req.params.link);
+
+  if (!link) {
+    throw new NotFoundException('Not found.');
+  }
+
+  await link.delete();
+
+  return res.status(200).json({ message: 'Link deleted.' });
+}

--- a/src/Functions/destroyLink.spec.js
+++ b/src/Functions/destroyLink.spec.js
@@ -1,0 +1,27 @@
+/// <reference types="jest" />
+
+import Link from '../Models/Link';
+import { dropTable, fresh } from '../helpers';
+import { deleteJson } from '../testing';
+
+beforeEach(() => dropTable(Link));
+
+describe('destroyLink', () => {
+  test('It should destroy links', async () => {
+    const link = await Link.create({
+      key: 'xyz82f',
+      url: 'http://www.example.com',
+    });
+
+    const response = await deleteJson(`/${link.key}`);
+
+    expect(response.status).toBe(200);
+    expect(await fresh(link)).toBeUndefined();
+  });
+
+  test('It should handle missing links', async () => {
+    const response = await deleteJson(`/xyz123`);
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import asyncHandler from 'express-async-handler';
 import auth from './Middleware/auth';
 import notFound from './Middleware/notFound';
 import createLink from './Functions/createLink';
+import destroyLink from './Functions/destroyLink';
 import errorHandler from './Middleware/errorHandler';
 
 const app = express();
@@ -15,6 +16,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 
 // Routes:
 app.post('/', [auth], asyncHandler(createLink));
+app.delete('/:link', [auth], asyncHandler(destroyLink));
 
 // Attach terminal "not found" & error handler
 // middleware for when things go awry:


### PR DESCRIPTION
### What's this PR do?

This pull request adds Bert's final ability - to destroy! 😱 The `DELETE /{link}` endpoint removes the given short-link from Bertly's link table, in case we made a link by mistake.

### How should this be reviewed?

There's some code, and there's a test! 💥 

### Any background context you want to provide?

🧨 

### Relevant tickets

References [Pivotal #172799443](https://www.pivotaltracker.com/story/show/172799443).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
