### PR TITLE
Add authentication to Bertly 2.0's "create" and "destroy" routes, and some config validation.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_URL="http://localhost:3000"
 APP_SECRET="secret-hash-salt"
 NODE_ENV=development
 LOG_LEVEL=info
+PORT=3000
 
 STORAGE_DRIVER=local
 

--- a/config/app.js
+++ b/config/app.js
@@ -1,6 +1,8 @@
 import { assert } from '@sindresorhus/is';
 
-import { env } from '.';
+import { env, oneOf } from '.';
+
+const NODE_ENV = env('NODE_ENV', oneOf('development', 'test', 'production'));
 
 export default {
   /**
@@ -18,7 +20,7 @@ export default {
    *
    * @type {Boolean}
    */
-  debug: env('NODE_ENV') !== 'production',
+  debug: NODE_ENV !== 'production',
 
   /**
    * The base application URL, used to redirect to canonical

--- a/config/app.js
+++ b/config/app.js
@@ -1,3 +1,7 @@
+import { assert } from '@sindresorhus/is';
+
+import { env } from '.';
+
 export default {
   /**
    * The application name (used to identify this particular
@@ -5,7 +9,7 @@ export default {
    *
    * @type {String}
    */
-  name: process.env.APP_NAME || 'bertly',
+  name: env('APP_NAME', assert.nonEmptyString),
 
   /**
    * Are we running in a production environment? This hide
@@ -14,7 +18,7 @@ export default {
    *
    * @type {Boolean}
    */
-  debug: process.env.NODE_ENV !== 'production',
+  debug: env('NODE_ENV') !== 'production',
 
   /**
    * The base application URL, used to redirect to canonical
@@ -22,19 +26,19 @@ export default {
    *
    * @type {String}
    */
-  url: process.env.APP_URL,
+  url: env('APP_URL', assert.urlString),
 
   /**
    * The port that traffic should be served from.
    *
    * @type {String}
    */
-  port: process.env.PORT || 3000,
+  port: env('PORT', assert.integer, 3000),
 
   /**
    * A secret used to "salt" our shortlinks.
    *
    * @type {String}
    */
-  secret: process.env.APP_SECRET,
+  secret: env('APP_SECRET', assert.nonEmptyString),
 };

--- a/config/app.js
+++ b/config/app.js
@@ -35,7 +35,7 @@ export default {
    *
    * @type {String}
    */
-  port: env('PORT', assert.integer, 3000),
+  port: env('PORT', assert.integer),
 
   /**
    * A secret used to "salt" our shortlinks.

--- a/config/auth.js
+++ b/config/auth.js
@@ -1,0 +1,16 @@
+export default {
+  /**
+   * The header that Bertly's static API key will be
+   * provided under.
+   *
+   * @type {String}
+   */
+  header: process.env.BERTLY_API_KEY_NAME || 'X-BERTLY-API-Key',
+
+  /**
+   * Bertly's static API key. This cannot be empty.
+   *
+   * @type {String}
+   */
+  key: process.env.BERTLY_API_KEY,
+};

--- a/config/auth.js
+++ b/config/auth.js
@@ -1,3 +1,6 @@
+import { env } from '.';
+import { assert } from '@sindresorhus/is';
+
 export default {
   /**
    * The header that Bertly's static API key will be
@@ -5,12 +8,12 @@ export default {
    *
    * @type {String}
    */
-  header: process.env.BERTLY_API_KEY_NAME || 'X-BERTLY-API-Key',
+  header: env('BERTLY_API_KEY_NAME', assert.nonEmptyString),
 
   /**
    * Bertly's static API key. This cannot be empty.
    *
    * @type {String}
    */
-  key: process.env.BERTLY_API_KEY,
+  key: env('BERTLY_API_KEY', assert.nonEmptyString),
 };

--- a/config/index.js
+++ b/config/index.js
@@ -8,6 +8,22 @@ import database from './database';
 import filesystem from './filesystem';
 
 /**
+ * Creates a validator that ensures one of a provided set of values.
+ * @param {...*} expectedValues
+ */
+export function oneOf(...expectedValues) {
+  return given => {
+    if (expectedValues.some(expected => given == expected)) {
+      return true;
+    }
+
+    throw new TypeError(
+      `Expected one of [${expectedValues}], received \`${given}\`.`
+    );
+  };
+}
+
+/**
  * Load an environment variable.
  *
  * @param {String} name

--- a/config/index.js
+++ b/config/index.js
@@ -30,13 +30,8 @@ export function oneOf(...expectedValues) {
  * @param {Assert} validator
  * @param {*} default
  */
-export function env(name, validator = null, defaultValue = null) {
+export function env(name, validator = null) {
   let variable = process.env[name];
-
-  // If not set, use the default:
-  if (!variable) {
-    variable = defaultValue;
-  }
 
   // Optionally, we can pass a type validator (from '@sindresorhus/is') to
   // throw an error if an improperly formatted environment variable is set:

--- a/config/index.js
+++ b/config/index.js
@@ -31,7 +31,16 @@ export function oneOf(...expectedValues) {
  * @param {*} default
  */
 export function env(name, validator = null) {
-  let variable = process.env[name];
+  let variable = process.env[name] || '';
+
+  // Parse strings to appropriate JavaScript types:
+  if (/^\d+$/.test(variable)) {
+    variable = parseInt(variable);
+  }
+
+  if (/true|false/i.test(variable)) {
+    variable = new Boolean(variable);
+  }
 
   // Optionally, we can pass a type validator (from '@sindresorhus/is') to
   // throw an error if an improperly formatted environment variable is set:

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 
 import app from './app';
+import auth from './auth';
 import database from './database';
 import filesystem from './filesystem';
 
@@ -11,7 +12,7 @@ import filesystem from './filesystem';
  * @param {mixed} defaultValue
  */
 export default (key, defaultValue = null) => {
-  const config = { app, database, filesystem };
+  const config = { app, auth, database, filesystem };
 
   return get(config, key, defaultValue);
 };

--- a/config/index.js
+++ b/config/index.js
@@ -1,9 +1,48 @@
 import { get } from 'lodash';
+import { error, debug } from 'heroku-logger';
+import { Assert } from '@sindresorhus/is';
 
 import app from './app';
 import auth from './auth';
 import database from './database';
 import filesystem from './filesystem';
+
+/**
+ * Load an environment variable.
+ *
+ * @param {String} name
+ * @param {Assert} validator
+ * @param {*} default
+ */
+export function env(name, validator = null, defaultValue = null) {
+  let variable = process.env[name];
+
+  // If not set, use the default:
+  if (!variable) {
+    variable = defaultValue;
+  }
+
+  // Optionally, we can pass a type validator (from '@sindresorhus/is') to
+  // throw an error if an improperly formatted environment variable is set:
+  if (validator) {
+    try {
+      validator(variable);
+    } catch (err) {
+      const message = `The '${name}' environment variable is invalid: ${err.message}`;
+      error(message, { [name]: variable });
+
+      // Make sure that this registers as a failure for Jest, and gives some
+      // instructions on how to set environment variables for the test runner:
+      if (typeof jest !== 'undefined') {
+        throw `${message}\n💡 You can configure Jest's environment variables in 'jest.beforeAll.js'.`;
+      }
+
+      process.exit(1);
+    }
+  }
+
+  return variable;
+}
 
 /**
  * Get the requested config, or use default.

--- a/jest.beforeAll.js
+++ b/jest.beforeAll.js
@@ -11,3 +11,5 @@ AWS.config.update({
 process.env.APP_SECRET = 'testing';
 process.env.LOG_LEVEL = 'error';
 process.env.STORAGE_DRIVER = 'local';
+process.env.BERTLY_API_KEY_HEADER = 'X-BERTLY-API-KEY';
+process.env.BERTLY_API_KEY = 'secret1';

--- a/jest.beforeAll.js
+++ b/jest.beforeAll.js
@@ -8,8 +8,10 @@ AWS.config.update({
 });
 
 // Configure test environment variables:
+process.env.APP_NAME = 'dosomething-bertly-test';
+process.env.APP_URL = 'https://localhost:3000';
 process.env.APP_SECRET = 'testing';
 process.env.LOG_LEVEL = 'error';
 process.env.STORAGE_DRIVER = 'local';
-process.env.BERTLY_API_KEY_HEADER = 'X-BERTLY-API-KEY';
+process.env.BERTLY_API_KEY_NAME = 'X-BERTLY-API-KEY';
 process.env.BERTLY_API_KEY = 'secret1';

--- a/jest.beforeAll.js
+++ b/jest.beforeAll.js
@@ -12,6 +12,7 @@ process.env.APP_NAME = 'dosomething-bertly-test';
 process.env.APP_URL = 'https://localhost:3000';
 process.env.APP_SECRET = 'testing';
 process.env.LOG_LEVEL = 'error';
+process.env.PORT = 3000;
 process.env.STORAGE_DRIVER = 'local';
 process.env.BERTLY_API_KEY_NAME = 'X-BERTLY-API-KEY';
 process.env.BERTLY_API_KEY = 'secret1';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,10 +1414,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+      "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
     },
     "@sinonjs/commons": {
       "version": "1.7.2",
@@ -3588,6 +3587,14 @@
         "p-cancelable": "^1.0.0",
         "to-readable-stream": "^1.0.0",
         "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "npm run dev:dynamo & npm run dev:app",
-    "dev:app": "nodemon --ignore bootstrap/storage --exec babel-node -r dotenv/config bootstrap/local.js",
+    "dev:app": "nodemon bootstrap/local.js",
     "dev:dynamo": "node bootstrap/local-dynamo.js",
     "test": "jest --watch --runInBand",
     "test:ci": "jest --ci --runInBand"
@@ -45,6 +45,18 @@
       "<rootDir>/bootstrap/"
     ]
   },
+  "nodemonConfig": {
+    "execMap": {
+      "js": "babel-node -r dotenv/config"
+    },
+    "watch": [
+      "src",
+      "config",
+      "package.json",
+      "package-lock.json",
+      ".env"
+    ]
+  },
   "prettier": {
     "singleQuote": true,
     "arrowParens": "avoid"
@@ -71,6 +83,7 @@
     "supertest": "^4.0.2"
   },
   "dependencies": {
+    "@sindresorhus/is": "^2.1.1",
     "@slynova/flydrive": "^1.0.0-0",
     "aws-sdk": "^2.677.0",
     "body-parser": "^1.19.0",

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -5,10 +5,12 @@ import { postJson, dropTable } from '../testing';
 
 beforeEach(() => dropTable(Link));
 
+const authenticated = { 'X-Bertly-API-Key': 'secret1' };
+
 describe('createLink', () => {
   test('It should create links', async () => {
     const url = 'https://www.example.com';
-    const response = await postJson('/', { url });
+    const response = await postJson('/', { url }, authenticated);
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
@@ -21,7 +23,7 @@ describe('createLink', () => {
       url: 'http://www.example.com',
     });
 
-    const response = await postJson('/', { url: link.url });
+    const response = await postJson('/', { url: link.url }, authenticated);
 
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('key', link.key);
@@ -35,10 +37,16 @@ describe('createLink', () => {
       '_campaign&utm_medium=sms&utm_campaign=sms_weekly_2020_05_11&user_' +
       'id=55be62d4469c64182b91992b&broadcast_id=6v1RJUUmrWN2Ode0EW6lH';
 
-    const response = await postJson('/', { url });
+    const response = await postJson('/', { url }, authenticated);
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
     expect(response.body).toHaveProperty('url', url);
+  });
+
+  test('It should require authentication', async () => {
+    const response = await postJson('/', { url: 'https://www.drupal.org' });
+
+    expect(response.status).toBe(403);
   });
 });

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -47,6 +47,6 @@ describe('createLink', () => {
   test('It should require authentication', async () => {
     const response = await postJson('/', { url: 'https://www.drupal.org' });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
   });
 });

--- a/src/Functions/destroyLink.spec.js
+++ b/src/Functions/destroyLink.spec.js
@@ -30,6 +30,6 @@ describe('destroyLink', () => {
   test('It should require authentication', async () => {
     const response = await deleteJson(`/xyz123`);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
   });
 });

--- a/src/Functions/destroyLink.spec.js
+++ b/src/Functions/destroyLink.spec.js
@@ -4,6 +4,8 @@ import Link from '../Models/Link';
 import { fresh } from '../helpers';
 import { deleteJson, dropTable } from '../testing';
 
+const authenticated = { 'X-Bertly-API-Key': 'secret1' };
+
 beforeEach(() => dropTable(Link));
 
 describe('destroyLink', () => {
@@ -13,15 +15,21 @@ describe('destroyLink', () => {
       url: 'http://www.example.com',
     });
 
-    const response = await deleteJson(`/${link.key}`);
+    const response = await deleteJson(`/${link.key}`, null, authenticated);
 
     expect(response.status).toBe(200);
     expect(await fresh(link)).toBeUndefined();
   });
 
   test('It should handle missing links', async () => {
-    const response = await deleteJson(`/xyz123`);
+    const response = await deleteJson(`/xyz123`, null, authenticated);
 
     expect(response.status).toBe(404);
+  });
+
+  test('It should require authentication', async () => {
+    const response = await deleteJson(`/xyz123`);
+
+    expect(response.status).toBe(403);
   });
 });

--- a/src/Middleware/auth.js
+++ b/src/Middleware/auth.js
@@ -1,5 +1,19 @@
 import * as Express from 'express';
 
+import config from '../../config';
+
+/**
+ *
+ * @param {Express.Request} req
+ * @returns {String}
+ */
+function getApiKey(req) {
+  // Express normalizes all request headers to lower-case:
+  const header = config('auth.header').toLowerCase();
+
+  return req.headers[header];
+}
+
 /**
  * Authenticate this request.
  *
@@ -8,7 +22,9 @@ import * as Express from 'express';
  * @param {Function} next
  */
 export default async function authenticate(req, res, next) {
-  // TODO: Check for API key here. :)
+  if (getApiKey(req) !== config('auth.key')) {
+    return res.status(403).json({ message: 'Invalid API key.' });
+  }
 
   next();
 }

--- a/src/Middleware/auth.js
+++ b/src/Middleware/auth.js
@@ -23,7 +23,7 @@ function getApiKey(req) {
  */
 export default async function authenticate(req, res, next) {
   if (getApiKey(req) !== config('auth.key')) {
-    return res.status(403).json({ message: 'Invalid API key.' });
+    return res.status(401).json({ message: 'Invalid API key.' });
   }
 
   next();


### PR DESCRIPTION
### What's this PR do?

This pull request adds simple header-based authentication to this applications "create link" and "destroy link" routes, so folks can't misrepresent our brand & cause a ruckus. I've also added some simple runtime validation for environment variables (so we don't forget to set them).

### How should this be reviewed?

I filled in the authentication middleware in 53191d4, and added environment variable validation (powered by [`@sindresorhus/is`](https://github.com/sindresorhus/is)) in 3b470cf. I also tidied up our `nodemon` config since it was getting a little cramped.

### Any background context you want to provide?

🔒

### Relevant tickets

References [Pivotal #172865466](https://www.pivotaltracker.com/story/show/172865466).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
