### PR TITLE
Validate request for the "create short-link" route.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,6 +1131,49 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hapi/address": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.1.tgz",
+      "integrity": "sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+    },
+    "@hapi/hoek": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+      "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+    },
+    "@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "requires": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "supertest": "^4.0.2"
   },
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
     "@sindresorhus/is": "^2.1.1",
     "@slynova/flydrive": "^1.0.0-0",
     "aws-sdk": "^2.677.0",

--- a/src/Exceptions/ValidationException.js
+++ b/src/Exceptions/ValidationException.js
@@ -1,5 +1,5 @@
 /**
- * Thrown if the requested resource could not be found.
+ * Thrown if the request has an invalid format.
  */
 export default class ValidationException extends Error {
   // ...

--- a/src/Exceptions/ValidationException.js
+++ b/src/Exceptions/ValidationException.js
@@ -1,0 +1,6 @@
+/**
+ * Thrown if the requested resource could not be found.
+ */
+export default class ValidationException extends Error {
+  // ...
+}

--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -5,7 +5,7 @@ import * as Express from 'express';
 
 import config from '../../config';
 import Link from '../Models/Link';
-import { randomChar } from '../helpers';
+import { randomChar, validate } from '../helpers';
 
 /**
  * Crete a new shortlink key.
@@ -39,8 +39,9 @@ async function generateKey() {
  * @param {Express.Response} res
  */
 export default async function createLink(req, res) {
-  // TODO: Validate input and return a 422 for bad stuff.
-  const { url } = req.body;
+  const { url } = validate(req, v => ({
+    url: v.string().uri().required(),
+  }));
 
   // Find & return already shortened link, if one exists.
   const result = await Link.query({ url }).limit(1).exec();

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -44,6 +44,20 @@ describe('createLink', () => {
     expect(response.body).toHaveProperty('url', url);
   });
 
+  test('It should require a URL', async () => {
+    const request = { url: null };
+    const response = await postJson('/', request, authenticated);
+
+    expect(response.status).toBe(422);
+  });
+
+  test('It should validate the provided URL', async () => {
+    const request = { url: '19 W 21st Street' };
+    const response = await postJson('/', request, authenticated);
+
+    expect(response.status).toBe(422);
+  });
+
   test('It should require authentication', async () => {
     const response = await postJson('/', { url: 'https://www.drupal.org' });
 

--- a/src/Middleware/errorHandler.js
+++ b/src/Middleware/errorHandler.js
@@ -3,6 +3,7 @@ import stackTrace from 'callsite-record';
 
 import config from '../../config';
 import NotFoundException from '../Exceptions/NotFoundException';
+import ValidationException from '../Exceptions/ValidationException';
 
 /**
  * Display a "not found" error.
@@ -34,6 +35,9 @@ export default function errorHandler(err, req, res, next) {
   // Handle any named exceptions:
   if (err instanceof NotFoundException) {
     return missing(err, req, res);
+  }
+  if (err instanceof ValidationException) {
+    return res.status(422).json({ message: err.message });
   }
 
   // Otherwise, we're handling a fatal error:

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,9 @@
 import chalk from 'chalk';
+import Joi, { Root } from '@hapi/joi';
 import { StorageManager } from '@slynova/flydrive';
 
 import config from '../config';
+import ValidationException from './Exceptions/ValidationException';
 
 /**
  * Get the FlyDrive filesystem disk.
@@ -72,4 +74,23 @@ export async function fresh(document) {
   const hashKey = Model.schema.getHashKey();
 
   return Model.get(document[hashKey]);
+}
+/**
+ * Validate the given request & return valid data.
+ *
+ * @param {*} req
+ * @param {(v: Root) => any} rules
+ * @returns {Object}
+ */
+export function validate(req, rules) {
+  // e.g. v => ({ url: v.string().uri() })
+  const schema = Joi.object(rules(Joi));
+
+  const { value, error } = schema.validate(req.body);
+
+  if (error) {
+    throw new ValidationException(error.message);
+  }
+
+  return value;
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds validation to the "create short-link" route, ensuring that `url` is present in the request & is a valid URL. This is powered by [Joi](https://hapi.dev/module/joi/), [Hapi](https://hapi.dev)'s validation module & from what I understand, the de-facto standard for validation in the Node world. (We use it in Blink, too!)

I've created a `validate` helper that neatly wraps this behavior in the route's function:

```js
const { url } = validate(req, v => ({
  url: v.string().uri().required(),
}));
```

### How should this be reviewed?

👀

### Any background context you want to provide?

👮‍♂️ 

### Relevant tickets

References [Pivotal #172799437](https://www.pivotaltracker.com/story/show/172799437).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
