### PR TITLE
Fix timeout issues running this application in Lambda.

### DIFF
--- a/bootstrap/lambda.js
+++ b/bootstrap/lambda.js
@@ -29,6 +29,5 @@ const app = require('../build/src/app').default;
 // all requests that hit a single Lambda "instance".
 const server = createServer(app);
 
-exports.handler = (event, context) => {
-  proxy(server, event, context);
-};
+// Our handler function is called by Lambda for each request:
+exports.handler = (event, context) => proxy(server, event, context);

--- a/bootstrap/lambda.js
+++ b/bootstrap/lambda.js
@@ -22,7 +22,7 @@ if (process.env.ENABLE_ENHANCED_XRAY) {
 const { createServer, proxy } = require('aws-serverless-express');
 
 // We use the compiled JavaScript (from 'npm run compile') in production:
-const app = require('../build/src/app');
+const app = require('../build/src/app').default;
 
 // Finally, we create a server instance & use it to respond to API
 // Gateway events. This "server" instance is shared between

--- a/config/filesystem.js
+++ b/config/filesystem.js
@@ -23,7 +23,7 @@ export default {
     s3: {
       driver: 's3',
       region: 'us-east-1',
-      bucket: process.env.AWS_S3_BUCKET,
+      bucket: process.env.S3_BUCKET,
     },
   },
 };

--- a/config/filesystem.js
+++ b/config/filesystem.js
@@ -23,8 +23,6 @@ export default {
     s3: {
       driver: 's3',
       region: 'us-east-1',
-      key: process.env.AWS_ACCESS_KEY,
-      secret: process.env.AWS_SECRET_KEY,
       bucket: process.env.AWS_S3_BUCKET,
     },
   },


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue that were causing Lambda requests to time out:

📤 Correctly reads the `.default` property, which is where `export default` is found when importing a module from CommonJS. (Before, we'd be be sending an object `{ default: app }` to the server, which it wouldn't be able to respond to... hence timeouts). 87585ae

🍃 Tidies up the helper function & adds a bit more documentation. 9d7eba7

🍃 Removes unused AWS config vars. (We give our Lambda function AWS permissions through its execution role, not through environment variables.) ad73499

🧃 Renames `AWS_S3_BUCKET` to `S3_BUCKET` to match our [Terraform module](https://github.com/DoSomething/infrastructure/blob/71c8421279c180f5e6df24468093f24902c56279/components/s3_bucket/main.tf#L178). d33da32

### How should this be reviewed?

Honestly, it's probably easiest to just review all at once! But it's broken into commits if it helps!

### Any background context you want to provide?

This should close out this ticket, and unblocks us from working on the backfill scripts.

### Relevant tickets

References [Pivotal #172652592](https://www.pivotaltracker.com/story/show/172652592).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
