### PR TITLE
Add transformer for standard JSON responses.

### DIFF
--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -5,6 +5,7 @@ import * as Express from 'express';
 
 import config from '../../config';
 import Link from '../Models/Link';
+import { transform } from '../Transformers/LinkTransfomer';
 import { randomChar, validate, user, context } from '../helpers';
 import ValidationException from '../Exceptions/ValidationException';
 
@@ -65,7 +66,7 @@ export default async function createLink(req, res) {
       ...context(req),
     });
 
-    return res.json(existingLink);
+    return res.json(transform(existingLink));
   }
 
   // If we haven't yet shortened this URL, make new shortlink:
@@ -77,5 +78,5 @@ export default async function createLink(req, res) {
     ...context(req),
   });
 
-  return res.status(201).json(link);
+  return res.status(201).json(transform(link));
 }

--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -22,7 +22,7 @@ async function generateKey() {
   // keeps its own auto-incremented counter for making shortlinks, below:
   const partition = await Link.update(
     { key: `${randomChar()}${randomChar()}` },
-    { $ADD: { counter: 1 } }
+    { $ADD: { count: 1 } }
   );
 
   // We can then use hashids <https://hashids.org> to generate short
@@ -32,7 +32,7 @@ async function generateKey() {
   const id = new HashId(config('app.secret'), 5);
 
   // e.g. 'bSlejRe'
-  return `${partition.key}${id.encode(partition.counter)}`;
+  return `${partition.key}${id.encode(partition.count)}`;
 }
 
 /**

--- a/src/Functions/inspectLink.js
+++ b/src/Functions/inspectLink.js
@@ -1,6 +1,7 @@
 import * as Express from 'express';
 
 import Link from '../Models/Link';
+import { transform } from '../Transformers/LinkTransfomer';
 import NotFoundException from '../Exceptions/NotFoundException';
 
 /**
@@ -17,5 +18,5 @@ export default async function inspectLink(req, res) {
     throw new NotFoundException('Not found');
   }
 
-  return res.json(link);
+  return res.json(transform(link));
 }

--- a/src/Functions/inspectLink.spec.js
+++ b/src/Functions/inspectLink.spec.js
@@ -17,7 +17,7 @@ describe('inspectLink', () => {
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('key', link.key);
     expect(response.body).toHaveProperty('url', link.url);
-    expect(response.body).toHaveProperty('counter');
+    expect(response.body).toHaveProperty('count');
   });
 
   test('It should handle missing links', async () => {

--- a/src/Functions/visitLink.js
+++ b/src/Functions/visitLink.js
@@ -45,7 +45,7 @@ export default async function visitLink(req, res) {
   // Update the link's "visits" counter & log details for analytics:
   // TODO: We should be able to finish this asynchronously after sending
   // the response, but it causes Jest issues. <https://git.io/JfRa3>
-  await Link.update({ key: link.key }, { $ADD: { counter: 1 } });
+  await Link.update({ key: link.key }, { $ADD: { count: 1 } });
   storeClickEvent(link, req);
 
   return res.redirect(link.url);

--- a/src/Models/Link.js
+++ b/src/Models/Link.js
@@ -18,7 +18,7 @@ const schema = new Schema(
         global: true,
       },
     },
-    counter: {
+    count: {
       type: Number,
       default: 0,
     },

--- a/src/Transformers/LinkTransfomer.js
+++ b/src/Transformers/LinkTransfomer.js
@@ -10,9 +10,9 @@ import config from '../../config';
  */
 export const transform = link => ({
   key: link.key,
+  count: link.count,
   url: link.url,
   url_short: new URL(link.key, config('app.url')),
-  count: link.count,
   updatedAt: link.updatedAt.toISOString(),
   createdAt: link.createdAt.toISOString(),
 });

--- a/src/Transformers/LinkTransfomer.js
+++ b/src/Transformers/LinkTransfomer.js
@@ -12,8 +12,7 @@ export const transform = link => ({
   key: link.key,
   url: link.url,
   url_short: new URL(link.key, config('app.url')),
-  counter: link.counter, // @deprecated: We'll remove this in the future.
-  count: link.counter,
+  count: link.count,
   updatedAt: link.updatedAt.toISOString(),
   createdAt: link.createdAt.toISOString(),
 });

--- a/src/Transformers/LinkTransfomer.js
+++ b/src/Transformers/LinkTransfomer.js
@@ -1,0 +1,19 @@
+import { URL } from 'url';
+
+import config from '../../config';
+
+/**
+ * This defines our response format for links.
+ *
+ * @param {Link} link
+ * @return {Object}
+ */
+export const transform = link => ({
+  key: link.key,
+  url: link.url,
+  url_short: new URL(link.key, config('app.url')),
+  counter: link.counter, // @deprecated: We'll remove this in the future.
+  count: link.counter,
+  updatedAt: link.updatedAt.toISOString(),
+  createdAt: link.createdAt.toISOString(),
+});


### PR DESCRIPTION
### What's this PR do?

This pull request adds a LinkTransformer, so that we can use the same response format everywhere we return a "link" in this application. For example, for `/Nx8OKyE/info`:

```js
{
  "key": "Nx8OKyE",
  "count": 0,
  "url": "https://www.dosomething.org/us/campaigns",
  "url_short": "http://localhost:3000/Nx8OKyE",
  "updatedAt": "2020-06-02T15:35:25.400Z",
  "createdAt": "2020-06-02T15:35:25.400Z"
}
```

I've also renamed the `counter` field to `count` (to match the existing response format).

### How should this be reviewed?

One fun gotcha – Bertly's existing `url` field is ambiguous. On the [Create Short-Link](https://github.com/DoSomething/bertly/tree/master/documentation#create-short-link) route, it's the short URL. On the [Inspect Short-Link](https://github.com/DoSomething/bertly/tree/master/documentation#view-statistics) route, it's the long URL. I don't believe we actually use the "inspect" link anywhere aside from debugging, so this change should not break anything. (For example, we read counts from the "create" endpoint [in Phoenix](https://github.com/DoSomething/phoenix-next/blob/abecd18eb47ea9bfddd492efb71de275514cec48/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js#L32-L33).)

### Any background context you want to provide?

This follows the same [Transformer](https://fractal.thephpleague.com/transformers/) pattern we use in our other applications.

### Relevant tickets

References [Pivotal #172844479](https://www.pivotaltracker.com/story/show/172844479).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
