### PR TITLE
Normalize URLs before querying/saving.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3265,6 +3265,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
         }
       }
     },
@@ -8428,9 +8433,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
+      "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw=="
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "heroku-logger": "^0.3.3",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
+    "normalize-url": "^5.0.0",
     "openid-client": "^3.15.1",
     "p-memoize": "^4.0.0",
     "redis": "^3.0.2",

--- a/scripts/migrate-links.js
+++ b/scripts/migrate-links.js
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import { info } from 'heroku-logger';
 
 import Link from '../src/Models/Link';
+import { normalizeUrl } from '../src/helpers';
 
 // Configure storage connections for AWS, Redis, and RDS:
 AWS.config.update({ region: 'us-east-1' });
@@ -38,7 +39,10 @@ const keysMatching = async function* (pattern, initialCursor = '0') {
 
     // Write link record to DynamoDB:
     info('Migrating shortlink.', { key, url });
-    await Link.update({ key }, { url, createdAt: new Date() });
+    await Link.update(
+      { key },
+      { url: normalizeUrl(url), createdAt: new Date() }
+    );
   }
 
   console.log('Done!');

--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -6,7 +6,7 @@ import * as Express from 'express';
 import config from '../../config';
 import Link from '../Models/Link';
 import { transform } from '../Transformers/LinkTransfomer';
-import { randomChar, validate, user, context } from '../helpers';
+import { randomChar, validate, user, context, normalizeUrl } from '../helpers';
 import ValidationException from '../Exceptions/ValidationException';
 
 const ALLOWED_DOMAINS = config('domains');
@@ -43,9 +43,12 @@ async function generateKey() {
  * @param {Express.Response} res
  */
 export default async function createLink(req, res) {
-  const { url } = validate(req, v => ({
+  const body = validate(req, v => ({
     url: v.string().uri().required(),
   }));
+
+  // Normalize the URL before we query or save it:
+  const url = normalizeUrl(body.url);
 
   // If a non-staffer is performing this action, are they allowed to
   // shorten this particular URL? (Superusers can shorten anything.)

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -31,15 +31,25 @@ describe('createLink', () => {
   test('It can shorten very long URLs', async () => {
     const url =
       'https://www.dosomething.org/us/articles/13-ways-the-sports-world-' +
-      'is-stepping-up-during-the-coronavirus-pandemic?utm_source=content' +
-      '_campaign&utm_medium=sms&utm_campaign=sms_weekly_2020_05_11&user_' +
-      'id=55be62d4469c64182b91992b&broadcast_id=6v1RJUUmrWN2Ode0EW6lH';
+      'is-stepping-up-during-the-coronavirus-pandemic?broadcast_id=6v1RJ' +
+      'UUmrWN2Ode0EW6lH&user_id=55be62d4469c64182b91992b&utm_campaign=sm' +
+      's_weekly_2020_05_11&utm_medium=sms&utm_source=content_campaign';
 
     const response = await postJson('/', { url }, withApiKey());
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
     expect(response.body).toHaveProperty('url', url);
+  });
+
+  test('It normalizes URLs', async () => {
+    const url1 = 'https://www.example.com?a=hello&b=world';
+    const response1 = await postJson('/', { url: url1 }, withApiKey());
+
+    const url2 = 'https://www.example.com/?b=world&a=hello';
+    const response2 = await postJson('/', { url: url2 }, withApiKey());
+
+    expect(response1.key).toEqual(response2.key);
   });
 
   test('It should require a URL', async () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import Joi, { Root } from '@hapi/joi';
+import normalize from 'normalize-url';
 import { StorageManager } from '@slynova/flydrive';
 
 import config from '../config';
@@ -126,4 +127,26 @@ export function validate(req, rules) {
   }
 
   return value;
+}
+
+/**
+ * Normalize the given URL.
+ *
+ * @param {String} url
+ * @returns {String}
+ */
+export function normalizeUrl(url) {
+  // Options for 'normalize-url' <https://git.io/JfDQP>
+  const options = {
+    // For consistency with our old normalization logic, we'll
+    // keep 'www.' on our URLs raher than stripping it.
+    stripWWW: false,
+    // We want URLs to resolve to the same shortlink regardless
+    // of how the query parameters (UTMs, etc) are ordered.
+    sortQueryParameters: true,
+    // We do not want to remove any UTM parameters!
+    removeQueryParameters: [],
+  };
+
+  return normalize(url, options);
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a mutator to the `url` field to ensure we've normalized the URL before we save it to the database. This is a follow-up from https://github.com/DoSomething/bertly/pull/74#discussion_r435407693 that I'd like to merge in before we run the backfill (since some links will be re-normalized differently).

### How should this be reviewed?

👀

### Any background context you want to provide?

This uses the [`normalize-url`](https://github.com/sindresorhus/normalize-url) package. It uses slightly different normalization rules than the [`url-normalize`](https://pypi.org/project/url-normalize/) package we'd been using in Python.

In particular, we now trim trailing `/`s when possible & sort and URL-encode query parameters. (This should not have any impact on applications or metrics, but wanted to flag!)

### Relevant tickets

References [Pivotal #165507221](https://www.pivotaltracker.com/story/show/165507221).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
