### PR TITLE
Add logging when we shorten new links in Bertly 1.0

### DIFF
--- a/bertly.py
+++ b/bertly.py
@@ -78,6 +78,10 @@ def get_key_for_url(url):
     if key is None:
         counter = redis_client.incr('bertly:counter', 1)
         key = short_url.encode_url(int(counter))
+        
+        # Log any new links we've created so we can backfill them
+        # into DynamoDB without iterating over all links again:
+        print('Shortening new link: {}'.format(key))
 
         hash = hashlib.sha256(url.encode()).hexdigest()
         redis_client.set('bertly:url:{}'.format(hash), key)


### PR DESCRIPTION
### What's this PR do?

This pull request writes to our Papertrail logs whenever this application shortens a new link.

### How should this be reviewed?

👀

### Any background context you want to provide?

I'd like to be able to shorten the "diff" from after we've run our first full backfill without iterating over millions of records a second time! This will let us re-import from a simple CSV of keys.

### Relevant tickets

References [Pivotal #165507221](https://www.pivotaltracker.com/story/show/165507221).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
