### PR TITLE
Configure production deploys for Bertly 2.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,19 @@ workflows:
           filters:
             branches:
               only: master
+      - hold:
+          type: approval
+          requires:
+            - deploy-dev
+            - deploy-qa
+          filters:
+            branches:
+              only: master
+      - lambda/deploy:
+          name: deploy-production
+          app: dosomething-bertly
+          requires:
+            - hold
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
### What's this PR do?

This pull request configures Bertly's production deploy job. Like [our GraphQL app](https://github.com/DoSomething/graphql/blob/master/.circleci/config.yml), production deploys are gated by a "hold" task and will only run for builds on the `master` branch.

### How should this be reviewed?

👀

### Any background context you want to provide?

This unblocks me from running migrations on production & thus unblocks the backfill script!

### Relevant tickets

References [Pivotal #165507221](https://www.pivotaltracker.com/story/show/165507221).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
