### PR TITLE
Update scripts to run "catchup" backfill.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4578,6 +4578,11 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "gen-readlines": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/gen-readlines/-/gen-readlines-0.2.0.tgz",
+      "integrity": "sha1-b2rqBcjHrASx/lGFYsYD0uc2teo="
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "express": "^4.17.1",
     "express-async-handler": "^1.1.4",
     "express-jwt": "^6.0.0",
+    "gen-readlines": "^0.2.0",
     "hashids": "^2.2.1",
     "heroku-logger": "^0.3.3",
     "jsonwebtoken": "^8.5.1",

--- a/scripts/list-keys.py
+++ b/scripts/list-keys.py
@@ -1,0 +1,17 @@
+import short_url
+
+START_COUNTER = 46237404 # as of June 8th 6:00pm
+END_COUNTER = 48232176   # as of July 22nd 11:50am
+
+"""
+This script outputs any shortlink keys that Bertly would generate
+from the given START_COUNTER to END_COUNTER.
+
+ Usage:
+ $ python list-keys.txt > keys.txt
+
+"""
+if __name__ == "__main__":
+    for id in range(START_COUNTER, END_COUNTER):
+        key = short_url.encode_url(id)
+        print(key)

--- a/scripts/migrate-links.js
+++ b/scripts/migrate-links.js
@@ -12,25 +12,6 @@ AWS.config.update({ region: 'us-east-1' });
 
 const redisClient = redis.createClient({ url: process.env.REDIS_URL });
 const redisGet = promisify(redisClient.get).bind(redisClient);
-const redisScan = promisify(redisClient.scan).bind(redisClient);
-
-// Helper to cleanly run a Redis SCAN & track counter as we go.
-// Adapted from: https://dev.to/eastpole/redis-async-generators-3ed
-const keysMatching = async function* (pattern, initialCursor = '0') {
-  let cursor = initialCursor;
-
-  do {
-    info('Scanning for links', { cursor });
-
-    const [newCursor, keys] = await redisScan(cursor, 'MATCH', pattern);
-
-    for (const key of keys) {
-      yield key;
-    }
-
-    cursor = newCursor;
-  } while (cursor !== '0');
-};
 
 (async () => {
   for (const line of fromFile(__dirname + '/keys.txt')) {


### PR DESCRIPTION
### What's this PR do?

This pull request updates our `migrate-links` and `migrate-scripts` to run a "catchup" after our initial data migration.

### How should this be reviewed?

I've split this work into one commit per script:

🐍 I added a `list-keys.py` script in 493e785. This lists out any shortlink keys that would be generated between the two given Bertly "counters", using Python's `short_url` module. We'll then use this in our new link migration script...

🔗 Updates the link migration script to read that list of keys in f2c8daa (rather than iterating over the _whole_ database with `SCAN`). This uses [`gen-readlines`](https://github.com/neurosnap/gen-readlines) to efficiently read each line from the file we created above.

🐁 Updates the click migration script to only return clicks _after_ a given date in b87f10b. This allows us to specifically migrate clicks we know were created after the initial migration (rather than iterating over millions that we know already exist).

🍃 Finally, I removed an old helper that we're no longer using in 4d89841.

### Any background context you want to provide?

This is the last major step before we can flip the switch for Bertly 2.0 in production!

### Relevant tickets

References [Pivotal #173478226](https://www.pivotaltracker.com/story/show/173478226).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
