### PR TITLE
The 'url' key for this endpoint should return short URL.

### DIFF
--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -69,7 +69,12 @@ export default async function createLink(req, res) {
       ...context(req),
     });
 
-    return res.json(transform(existingLink));
+    return res.json({
+      ...transform(existingLink),
+      // TODO: Update applications to read 'url_short' instead.
+      url: new URL(existingLink.key, config('app.url')),
+      url_long: existingLink.url,
+    });
   }
 
   // If we haven't yet shortened this URL, make new shortlink:
@@ -81,5 +86,10 @@ export default async function createLink(req, res) {
     ...context(req),
   });
 
-  return res.status(201).json(transform(link));
+  return res.status(201).json({
+    ...transform(link),
+    // TODO: Update applications to read 'url_short' instead.
+    url: new URL(link.key, config('app.url')),
+    url_long: link.url,
+  });
 }

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -12,7 +12,8 @@ describe('createLink', () => {
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
-    expect(response.body).toHaveProperty('url', url);
+    expect(response.body).toHaveProperty('url');
+    expect(response.body).toHaveProperty('url_long', url);
   });
 
   test('It should not create duplicate links', async () => {
@@ -25,7 +26,7 @@ describe('createLink', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('key', link.key);
-    expect(response.body).toHaveProperty('url', link.url);
+    expect(response.body).toHaveProperty('url_long', link.url);
   });
 
   test('It can shorten very long URLs', async () => {
@@ -39,7 +40,7 @@ describe('createLink', () => {
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
-    expect(response.body).toHaveProperty('url', url);
+    expect(response.body).toHaveProperty('url_long', url);
   });
 
   test('It normalizes URLs', async () => {


### PR DESCRIPTION
### What's this PR do?

I missed that existing applications still expect the `url` parameter for the `POST /` route to return the _short_ URL, and so this is now breaking the existing API contract. As a quick fix, I've updated this to return the short URL.

### How should this be reviewed?

👀

### Any background context you want to provide?

I'd swapped `url` to consistently return the "long" URL (since that's how it's used on Bertly's other API endpoints), but forgot that things rely on this! Could've done a little better testing there. 😬

### Relevant tickets

Pivotal [#172652963](https://www.pivotaltracker.com/story/show/172652963)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
