### PR TITLE
Allow Phoenix to talk directly to Bertly.

### DIFF
--- a/config/domains.js
+++ b/config/domains.js
@@ -10,4 +10,5 @@ export default [
   'qa.dosomething.org',
   'dev.dosomething.org',
   'vote.dosomething.org',
+  'phoenix.test',
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -3635,6 +3635,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -8462,6 +8471,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "body-parser": "^1.19.0",
     "callsite-record": "^4.1.3",
     "cli-table": "^0.3.1",
+    "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "dynamoose": "^2.2.0",
     "esm": "^3.2.25",

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,4 @@
+import cors from 'cors';
 import express from 'express';
 import bodyParser from 'body-parser';
 import asyncHandler from 'express-async-handler';
@@ -11,6 +12,9 @@ import inspectLink from './Functions/inspectLink';
 import errorHandler from './Middleware/errorHandler';
 
 const app = express();
+
+// Allow cross-origin requests:
+app.use(cors());
 
 // We'll happily parse either JSON or URL-encoded bodies:
 app.use(bodyParser.json());


### PR DESCRIPTION
### What's this PR do?

This pull request adds the [`cors`](https://expressjs.com/en/resources/middleware/cors.html) middleware to Bertly, to allow web applications (like Phoenix) to talk directly to it (rather than relying on a proxy backend route). I've also added `phoenix.test` to our list of whitelisted domains so we can test Bertly when doing local development.

### How should this be reviewed?

👀

### Any background context you want to provide?

This unlocks some cleanup work in Phoenix, done in DoSomething/phoenix-next#2317.

### Relevant tickets

References [Pivotal #174166833](https://www.pivotaltracker.com/story/show/174166833).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
