### PR TITLE
Revert "The 'url' key for this endpoint should return short URL. (#81)"

### DIFF
--- a/src/Functions/createLink.js
+++ b/src/Functions/createLink.js
@@ -69,12 +69,7 @@ export default async function createLink(req, res) {
       ...context(req),
     });
 
-    return res.json({
-      ...transform(existingLink),
-      // TODO: Update applications to read 'url_short' instead.
-      url: new URL(existingLink.key, config('app.url')),
-      url_long: existingLink.url,
-    });
+    return res.json(transform(existingLink));
   }
 
   // If we haven't yet shortened this URL, make new shortlink:
@@ -86,10 +81,5 @@ export default async function createLink(req, res) {
     ...context(req),
   });
 
-  return res.status(201).json({
-    ...transform(link),
-    // TODO: Update applications to read 'url_short' instead.
-    url: new URL(link.key, config('app.url')),
-    url_long: link.url,
-  });
+  return res.status(201).json(transform(link));
 }

--- a/src/Functions/createLink.spec.js
+++ b/src/Functions/createLink.spec.js
@@ -12,8 +12,7 @@ describe('createLink', () => {
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
-    expect(response.body).toHaveProperty('url');
-    expect(response.body).toHaveProperty('url_long', url);
+    expect(response.body).toHaveProperty('url', url);
   });
 
   test('It should not create duplicate links', async () => {
@@ -26,7 +25,7 @@ describe('createLink', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('key', link.key);
-    expect(response.body).toHaveProperty('url_long', link.url);
+    expect(response.body).toHaveProperty('url', link.url);
   });
 
   test('It can shorten very long URLs', async () => {
@@ -40,7 +39,7 @@ describe('createLink', () => {
 
     expect(response.status).toBe(201);
     expect(response.body).toHaveProperty('key');
-    expect(response.body).toHaveProperty('url_long', url);
+    expect(response.body).toHaveProperty('url', url);
   });
 
   test('It normalizes URLs', async () => {


### PR DESCRIPTION
This reverts commit 529c3f1b3a0a489aa6c0e279327e9a1d53496996.

### What's this PR do?

This pull request reverts our fix in #81 which was needed to support existing API consumers using the `url` key to read the short URL. 

### How should this be reviewed?
🔙  👀 

### Any background context you want to provide?
We've updated the remaining client still using this field in https://github.com/DoSomething/gambit/pull/531

### Relevant tickets

References [Pivotal #174267470](https://www.pivotaltracker.com/story/show/174267470).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
